### PR TITLE
Add Serial Output to LED Blink code

### DIFF
--- a/blink/CMakeLists.txt
+++ b/blink/CMakeLists.txt
@@ -2,6 +2,10 @@ add_executable(blink
         blink.c
         )
 
+# enable usb output, and uart output
+pico_enable_stdio_usb(hello_usb 1)
+pico_enable_stdio_uart(hello_usb 1)
+
 # Pull in our pico_stdlib which pulls in commonly used features
 target_link_libraries(blink pico_stdlib)
 

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -5,15 +5,20 @@
  */
 
 #include "pico/stdlib.h"
+#include <stdio.h>
 
 int main() {
+    stdio_init_all();
     const uint LED_PIN = 25;
     gpio_init(LED_PIN);
     gpio_set_dir(LED_PIN, GPIO_OUT);
     while (true) {
+        printf("LED ON!\n");
         gpio_put(LED_PIN, 1);
         sleep_ms(250);
+        printf("LED OFF!\n");
         gpio_put(LED_PIN, 0);
         sleep_ms(250);
     }
 }
+


### PR DESCRIPTION
Generally, LED blink code also comes with serial output of LED ON and LED OFF, hence I feel this example be provided instead of bare blink.