### PR TITLE
Fix WS2812 Timing

### DIFF
--- a/pio/ws2812/ws2812.pio
+++ b/pio/ws2812/ws2812.pio
@@ -17,12 +17,13 @@
 
 .wrap_target
 bitloop:
-    out x, 1       side 0 [T3 - 1] ; Side-set still takes place when instruction stalls
-    jmp !x do_zero side 1 [T1 - 1] ; Branch on the bit we shifted out. Positive pulse
+    out x, 1       side 0 [3] ; Side-set still takes place when instruction stalls
+    jmp !x do_zero side 1 [2] ; Branch on the bit we shifted out. Positive pulse
 do_one:
-    jmp  bitloop   side 1 [T2 - 1] ; Continue driving high, for a long pulse
+    nop            side 1 [2] ; Continue driving high, for a long pulse
+    jmp  bitloop   side 0 ; Padding zero
 do_zero:
-    nop            side 0 [T2 - 1] ; Or drive low, for a short pulse
+    nop            side 0 [1] ; Or drive low, for a short pulse
 .wrap
 
 % c-sdk {


### PR DESCRIPTION
Original Timing: 1 => 840ns H + 360 ns L 0 => 240 ns H + 960 ns L (!There is a 10ns overrun of the upper limit.)
Correct Timing: 1 => 720ns H + 600 ns L 0 => 360 ns H + 720 ns L
Datasheet Timing: 1 => 350ns H + 800ns L 0 => 700ns H + 600ns L