### PR TITLE
Fix logic analyser for non-power-of-2 sample widths, and clean and comment (closes #29)

### DIFF
--- a/pio/logic_analyser/logic_analyser.c
+++ b/pio/logic_analyser/logic_analyser.c
@@ -66,7 +66,7 @@ void logic_analyser_arm(PIO pio, uint sm, uint dma_chan, uint32_t *capture_buf, 
                         uint trigger_pin, bool trigger_level) {
     pio_sm_set_enabled(pio, sm, false);
     // Need to clear _input shift counter_, as well as FIFO, because there may be
-    // partial ISR contents left over from a prevoius run. sm_restart does this.
+    // partial ISR contents left over from a previous run. sm_restart does this.
     pio_sm_clear_fifos(pio, sm);
     pio_sm_restart(pio, sm);
 


### PR DESCRIPTION
This fixes the PIO + DMA logic analyser example to handle non-power-of-2 sample widths correctly, and also generally cleans it up, adds more commentary, and sets the DMA to high bus priority so you should be able to crank the width all the way up to 32 bits. See #29