### PR TITLE
Added button debounce example in gpio_irqs

### DIFF
--- a/gpio/debounce_gpio_irq/CMakeLists.txt
+++ b/gpio/debounce_gpio_irq/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(debounce_gpio_irq
+        debounce_gpio_irq.c
+        )
+
+# Pull in our pico_stdlib which pulls in commonly used features
+target_link_libraries(debounce_gpio_irq pico_stdlib)
+
+# create map/bin/hex file etc.
+pico_add_extra_outputs(debounce_gpio_irq)
+
+# add url via pico_set_program_url
+example_auto_set_url(debounce_gpio_irq)

--- a/gpio/debounce_gpio_irq/debounce_gpio_irq.c
+++ b/gpio/debounce_gpio_irq/debounce_gpio_irq.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include "pico/stdlib.h"
+
+
+bool state;
+const uint LED_PIN = 25;
+
+// Debounce control
+unsigned long time = to_ms_since_boot(get_absolute_time());
+const int delayTime = 50; // Change according to the push-buttons
+
+
+void inter_test(uint gpio, uint32_t events) {
+    if ((to_ms_since_boot(get_absolute_time())-time)>delayTime) {
+        time = to_ms_since_boot(get_absolute_time());
+
+        printf("interrupt worked\n");
+        state = !state;
+        gpio_put(LED_PIN, state);
+    }
+}
+
+
+
+
+int main() {
+    stdio_init_all();
+
+    gpio_init(LED_PIN);
+    gpio_set_dir(LED_PIN, GPIO_OUT);
+
+    state = true;
+    gpio_put(LED_PIN, state);
+
+
+    gpio_init(2);
+    gpio_pull_up(2);
+
+    gpio_set_irq_enabled_with_callback(2, GPIO_IRQ_EDGE_FALL , true, &inter_test);
+
+
+    while(1) {}
+}


### PR DESCRIPTION
Yes, debounce is very basic, but that's the purpose of examples anyways.
The onboard LED and usb/uart is used to see the debounce working