### PR TITLE
Add `set_sys_clock_48mhz` to the PIO blink example

### DIFF
--- a/pio/pio_blink/blink.c
+++ b/pio/pio_blink/blink.c
@@ -13,6 +13,7 @@
 void blink_pin_forever(PIO pio, uint sm, uint offset, uint pin, uint freq);
 
 int main() {
+    set_sys_clock_48mhz();
     setup_default_uart();
 
     // todo get free sm


### PR DESCRIPTION
When I tried to run the PIO blink example on a brand new Raspberry Pi Pico board, I noticed the clock frequency of the blinking wasn't right (7.5 Hz instead of the expected 3 Hz on pin 0 for instance). This is simply due to the calculation `24M/frequency`, which implies a 48 MHz clock; for sake of simplicity, I suggest to add the line `set_sys_clock_48mhz();` to the example so that it works at the right frequency out of the box.