### PR TITLE
Update some of the SPI examples to use PICO_DEFAULT_SPI and binary_info

### DIFF
--- a/pio/spi/spi_flash.c
+++ b/pio/spi/spi_flash.c
@@ -114,8 +114,6 @@ int main() {
     gpio_init(PICO_DEFAULT_SPI_CSN_PIN);
     gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 1);
     gpio_set_dir(PICO_DEFAULT_SPI_CSN_PIN, GPIO_OUT);
-    // Make the CS pin available to picotool
-    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "CS"));
 
     uint offset = pio_add_program(spi.pio, &spi_cpha0_program);
     printf("Loaded program at %d\n", offset);
@@ -129,8 +127,8 @@ int main() {
                  PICO_DEFAULT_SPI_TX_PIN,
                  PICO_DEFAULT_SPI_RX_PIN
     );
-    // Make the SPI pins available to picotool
-    bi_decl(bi_3pins_with_func(PICO_DEFAULT_SPI_RX_PIN, PICO_DEFAULT_SPI_TX_PIN, PICO_DEFAULT_SPI_SCK_PIN, GPIO_FUNC_PIO0));
+    // Make the 'SPI' pins available to picotool
+    bi_decl(bi_4pins_with_names(PICO_DEFAULT_SPI_RX_PIN, "SPI RX", PICO_DEFAULT_SPI_TX_PIN, "SPI TX", PICO_DEFAULT_SPI_SCK_PIN, "SPI SCK", PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
 
     uint8_t page_buf[FLASH_PAGE_SIZE];
 

--- a/pio/spi/spi_flash.c
+++ b/pio/spi/spi_flash.c
@@ -7,15 +7,11 @@
 #include <stdio.h>
 
 #include "pico/stdlib.h"
+#include "pico/binary_info.h"
 #include "pio_spi.h"
 
 // This example uses PIO to erase, program and read back a SPI serial flash
 // memory.
-
-#define PIN_MISO 16
-#define PIN_MOSI 17
-#define PIN_SCK 18
-#define PIN_CS 19
 
 // ----------------------------------------------------------------------------
 // Generic serial flash code
@@ -102,17 +98,24 @@ void printbuf(const uint8_t buf[FLASH_PAGE_SIZE]) {
 
 int main() {
     stdio_init_all();
+#if !defined(PICO_DEFAULT_SPI_SCK_PIN) || !defined(PICO_DEFAULT_SPI_TX_PIN) || !defined(PICO_DEFAULT_SPI_RX_PIN) || !defined(PICO_DEFAULT_SPI_CSN_PIN)
+#warning pio/spi/spi_flash example requires a board with SPI pins
+    puts("Default SPI pins were not defined");
+#else
+
     puts("PIO SPI Example");
 
     pio_spi_inst_t spi = {
             .pio = pio0,
             .sm = 0,
-            .cs_pin = PIN_CS
+            .cs_pin = PICO_DEFAULT_SPI_CSN_PIN
     };
 
-    gpio_init(PIN_CS);
-    gpio_put(PIN_CS, 1);
-    gpio_set_dir(PIN_CS, GPIO_OUT);
+    gpio_init(PICO_DEFAULT_SPI_CSN_PIN);
+    gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 1);
+    gpio_set_dir(PICO_DEFAULT_SPI_CSN_PIN, GPIO_OUT);
+    // Make the CS pin available to picotool
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "CS"));
 
     uint offset = pio_add_program(spi.pio, &spi_cpha0_program);
     printf("Loaded program at %d\n", offset);
@@ -122,10 +125,12 @@ int main() {
                  31.25f,  // 1 MHz @ 125 clk_sys
                  false,   // CPHA = 0
                  false,   // CPOL = 0
-                 PIN_SCK,
-                 PIN_MOSI,
-                 PIN_MISO
+                 PICO_DEFAULT_SPI_SCK_PIN,
+                 PICO_DEFAULT_SPI_TX_PIN,
+                 PICO_DEFAULT_SPI_RX_PIN
     );
+    // Make the SPI pins available to picotool
+    bi_decl(bi_3pins_with_func(PICO_DEFAULT_SPI_RX_PIN, PICO_DEFAULT_SPI_TX_PIN, PICO_DEFAULT_SPI_SCK_PIN, GPIO_FUNC_PIO0));
 
     uint8_t page_buf[FLASH_PAGE_SIZE];
 
@@ -152,4 +157,5 @@ int main() {
     printbuf(page_buf);
 
     return 0;
+#endif
 }

--- a/spi/bme280_spi/bme280_spi.c
+++ b/spi/bme280_spi/bme280_spi.c
@@ -25,7 +25,7 @@
    GPIO 17 (pin 22) Chip select -> CSB/!CS on bme280 board
    GPIO 18 (pin 24) SCK/spi0_sclk -> SCL/SCK on bme280 board
    GPIO 19 (pin 25) MOSI/spi0_tx -> SDA/SDI on bme280 board
-   3.3v (pin 3;6) -> VCC on bme280 board
+   3.3v (pin 36) -> VCC on bme280 board
    GND (pin 38)  -> GND on bme280 board
 
    Note: SPI devices can have a number of different naming schemes for pins. See

--- a/spi/bme280_spi/bme280_spi.c
+++ b/spi/bme280_spi/bme280_spi.c
@@ -206,7 +206,7 @@ int main() {
     gpio_set_dir(PICO_DEFAULT_SPI_CSN_PIN, GPIO_OUT);
     gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 1);
     // Make the CS pin available to picotool
-    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "CS"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
 
     // See if SPI is working - interrograte the device for its I2C ID number, should be 0x60
     uint8_t id;

--- a/spi/bme280_spi/bme280_spi.c
+++ b/spi/bme280_spi/bme280_spi.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "pico/stdlib.h"
+#include "pico/binary_info.h"
 #include "hardware/spi.h"
 
 /* Example code to talk to a bme280 humidity/temperature/pressure sensor.
@@ -36,12 +37,6 @@
    https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf
 */
 
-#define PIN_MISO 16
-#define PIN_CS   17
-#define PIN_SCK  18
-#define PIN_MOSI 19
-
-#define SPI_PORT spi0
 #define READ_BIT 0x80
 
 int32_t t_fine;
@@ -110,24 +105,27 @@ uint32_t compensate_humidity(int32_t adc_H) {
     return (uint32_t) (v_x1_u32r >> 12);
 }
 
+#ifdef PICO_DEFAULT_SPI_CSN_PIN
 static inline void cs_select() {
     asm volatile("nop \n nop \n nop");
-    gpio_put(PIN_CS, 0);  // Active low
+    gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 0);  // Active low
     asm volatile("nop \n nop \n nop");
 }
 
 static inline void cs_deselect() {
     asm volatile("nop \n nop \n nop");
-    gpio_put(PIN_CS, 1);
+    gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 1);
     asm volatile("nop \n nop \n nop");
 }
+#endif
 
+#if defined(spi_default) && defined(PICO_DEFAULT_SPI_CSN_PIN)
 static void write_register(uint8_t reg, uint8_t data) {
     uint8_t buf[2];
     buf[0] = reg & 0x7f;  // remove read bit as this is a write
     buf[1] = data;
     cs_select();
-    spi_write_blocking(SPI_PORT, buf, 2);
+    spi_write_blocking(spi_default, buf, 2);
     cs_deselect();
     sleep_ms(10);
 }
@@ -138,9 +136,9 @@ static void read_registers(uint8_t reg, uint8_t *buf, uint16_t len) {
     // so we don't need to keep sending the register we want, just the first.
     reg |= READ_BIT;
     cs_select();
-    spi_write_blocking(SPI_PORT, &reg, 1);
+    spi_write_blocking(spi_default, &reg, 1);
     sleep_ms(10);
-    spi_read_blocking(SPI_PORT, 0, buf, len);
+    spi_read_blocking(spi_default, 0, buf, len);
     cs_deselect();
     sleep_ms(10);
 }
@@ -184,22 +182,31 @@ static void bme280_read_raw(int32_t *humidity, int32_t *pressure, int32_t *tempe
     *temperature = ((uint32_t) buffer[3] << 12) | ((uint32_t) buffer[4] << 4) | (buffer[5] >> 4);
     *humidity = (uint32_t) buffer[6] << 8 | buffer[7];
 }
+#endif
 
 int main() {
     stdio_init_all();
+#if !defined(spi_default) || !defined(PICO_DEFAULT_SPI_SCK_PIN) || !defined(PICO_DEFAULT_SPI_TX_PIN) || !defined(PICO_DEFAULT_SPI_RX_PIN) || !defined(PICO_DEFAULT_SPI_CSN_PIN)
+#warning spi/bme280_spi example requires a board with SPI pins
+    puts("Default SPI pins were not defined");
+#else
 
     printf("Hello, bme280! Reading raw data from registers via SPI...\n");
 
     // This example will use SPI0 at 0.5MHz.
-    spi_init(SPI_PORT, 500 * 1000);
-    gpio_set_function(PIN_MISO, GPIO_FUNC_SPI);
-    gpio_set_function(PIN_SCK, GPIO_FUNC_SPI);
-    gpio_set_function(PIN_MOSI, GPIO_FUNC_SPI);
+    spi_init(spi_default, 500 * 1000);
+    gpio_set_function(PICO_DEFAULT_SPI_RX_PIN, GPIO_FUNC_SPI);
+    gpio_set_function(PICO_DEFAULT_SPI_SCK_PIN, GPIO_FUNC_SPI);
+    gpio_set_function(PICO_DEFAULT_SPI_TX_PIN, GPIO_FUNC_SPI);
+    // Make the SPI pins available to picotool
+    bi_decl(bi_3pins_with_func(PICO_DEFAULT_SPI_RX_PIN, PICO_DEFAULT_SPI_TX_PIN, PICO_DEFAULT_SPI_SCK_PIN, GPIO_FUNC_SPI));
 
     // Chip select is active-low, so we'll initialise it to a driven-high state
-    gpio_init(PIN_CS);
-    gpio_set_dir(PIN_CS, GPIO_OUT);
-    gpio_put(PIN_CS, 1);
+    gpio_init(PICO_DEFAULT_SPI_CSN_PIN);
+    gpio_set_dir(PICO_DEFAULT_SPI_CSN_PIN, GPIO_OUT);
+    gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 1);
+    // Make the CS pin available to picotool
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "CS"));
 
     // See if SPI is working - interrograte the device for its I2C ID number, should be 0x60
     uint8_t id;
@@ -230,4 +237,5 @@ int main() {
     }
 
     return 0;
+#endif
 }

--- a/spi/mpu9250_spi/mpu9250_spi.c
+++ b/spi/mpu9250_spi/mpu9250_spi.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "pico/stdlib.h"
+#include "pico/binary_info.h"
 #include "hardware/spi.h"
 
 /* Example code to talk to a MPU9250 MEMS accelerometer and gyroscope.
@@ -117,11 +118,15 @@ int main() {
     gpio_set_function(PIN_MISO, GPIO_FUNC_SPI);
     gpio_set_function(PIN_SCK, GPIO_FUNC_SPI);
     gpio_set_function(PIN_MOSI, GPIO_FUNC_SPI);
+    // Make the SPI pins available to picotool
+    bi_decl(bi_3pins_with_func(PIN_MISO, PIN_MOSI, PIN_SCK, GPIO_FUNC_SPI));
 
     // Chip select is active-low, so we'll initialise it to a driven-high state
     gpio_init(PIN_CS);
     gpio_set_dir(PIN_CS, GPIO_OUT);
     gpio_put(PIN_CS, 1);
+    // Make the CS pin available to picotool
+    bi_decl(bi_1pin_with_name(PIN_CS, "CS"));
 
     mpu9250_reset();
 

--- a/spi/mpu9250_spi/mpu9250_spi.c
+++ b/spi/mpu9250_spi/mpu9250_spi.c
@@ -126,7 +126,7 @@ int main() {
     gpio_set_dir(PIN_CS, GPIO_OUT);
     gpio_put(PIN_CS, 1);
     // Make the CS pin available to picotool
-    bi_decl(bi_1pin_with_name(PIN_CS, "CS"));
+    bi_decl(bi_1pin_with_name(PIN_CS, "SPI CS"));
 
     mpu9250_reset();
 

--- a/spi/spi_dma/spi_dma.c
+++ b/spi/spi_dma/spi_dma.c
@@ -34,7 +34,7 @@ int main() {
     // Make the SPI pins available to picotool
     bi_decl(bi_3pins_with_func(PICO_DEFAULT_SPI_RX_PIN, PICO_DEFAULT_SPI_TX_PIN, PICO_DEFAULT_SPI_SCK_PIN, GPIO_FUNC_SPI));
     // Make the CS pin available to picotool
-    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "CS"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
 
     // Grab some unused dma channels
     const uint dma_tx = dma_claim_unused_channel(true);

--- a/spi/spi_flash/spi_flash.c
+++ b/spi/spi_flash/spi_flash.c
@@ -126,7 +126,7 @@ int main() {
     gpio_put(PICO_DEFAULT_SPI_CSN_PIN, 1);
     gpio_set_dir(PICO_DEFAULT_SPI_CSN_PIN, GPIO_OUT);
     // Make the CS pin available to picotool
-    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "CS"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
 
     printf("SPI initialised, let's goooooo\n");
 


### PR DESCRIPTION
This follows on from https://github.com/raspberrypi/pico-sdk/pull/225

I haven't actually tested any of these examples, but I have double-checked the changes I've made. I didn't use PICO_DEFAULT_SPI for `spi/mpu9250_spi` because that would also involve updating the [wiring diagram](https://github.com/raspberrypi/pico-examples/tree/master/spi/mpu9250_spi) which I don't have time to do right now.