### PR TITLE
bus_scan: use i2c_default rather than i2c0

### DIFF
--- a/i2c/bus_scan/bus_scan.c
+++ b/i2c/bus_scan/bus_scan.c
@@ -66,7 +66,7 @@ int main() {
         if (reserved_addr(addr))
             ret = PICO_ERROR_GENERIC;
         else
-            ret = i2c_read_blocking(i2c0, addr, &rxdata, 1, false);
+            ret = i2c_read_blocking(i2c_default, addr, &rxdata, 1, false);
 
         printf(ret < 0 ? "." : "@");
         printf(addr % 16 == 15 ? "\n" : "  ");


### PR DESCRIPTION
When calling ```i2c_read_blocking```, use ```i2c_default``` rather than ```i2c0```.