### PR TITLE
Added .gitignore for build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,1 @@
-.idea
-.vscode
-_deps
-cmake-*
-build
-.DS_Store
-*.pdf
+build/


### PR DESCRIPTION
Ignoring `build/`.

I realize that I and other seasoned devs will know to put this in their global `.gitignore`, but in the spirit of lowering the barriers of access and it-works-out-of-the-box, I think we should actually set it somewhere, even if it isn't here. If you disagree with putting this here, please share the repo for the default home dir skeleton or another appropriate location.