### PR TITLE
Update hello_rtc.c

### DIFF
--- a/rtc/hello_rtc/hello_rtc.c
+++ b/rtc/hello_rtc/hello_rtc.c
@@ -32,8 +32,9 @@ int main() {
     rtc_init();
     rtc_set_datetime(&t);
 
-    // clk_sys is >2000x faster than clk_rtc, so datetime is not transferred completely when rtc_get_datetime() is called
-    sleep_us(20);
+    // clk_sys is >2000x faster than clk_rtc, so datetime is not updated immediately when rtc_get_datetime() is called.
+    // tbe dealys is up to 3 RTC cycles (which is 64us with the default clock settings)
+    sleep_us(64);
 
     // Print the time
     while (true) {

--- a/rtc/hello_rtc/hello_rtc.c
+++ b/rtc/hello_rtc/hello_rtc.c
@@ -33,7 +33,7 @@ int main() {
     rtc_set_datetime(&t);
 
     // clk_sys is >2000x faster than clk_rtc, so datetime is not updated immediately when rtc_get_datetime() is called.
-    // tbe dealys is up to 3 RTC cycles (which is 64us with the default clock settings)
+    // tbe delay is up to 3 RTC clock cycles (which is 64us with the default clock settings)
     sleep_us(64);
 
     // Print the time

--- a/rtc/hello_rtc/hello_rtc.c
+++ b/rtc/hello_rtc/hello_rtc.c
@@ -32,6 +32,9 @@ int main() {
     rtc_init();
     rtc_set_datetime(&t);
 
+    // clk_sys is >2000x faster than clk_rtc, so datetime is not transferred completely when rtc_get_datetime() is called
+    sleep_us(20);
+
     // Print the time
     while (true) {
         rtc_get_datetime(&t);


### PR DESCRIPTION
when RTC gets new datetime values, it needs a few clocks to apply them. If get_datetime() is called before this is done, the first output on serial is wrong