### PR TITLE
Fix pio_blink frequency calculation

### DIFF
--- a/pio/pio_blink/blink.c
+++ b/pio/pio_blink/blink.c
@@ -31,5 +31,5 @@ void blink_pin_forever(PIO pio, uint sm, uint offset, uint pin, uint freq) {
     pio_sm_set_enabled(pio, sm, true);
 
     printf("Blinking pin %d at %d Hz\n", pin, freq);
-    pio->txf[sm] = clock_get_hz(clk_sys) / 2 * freq;
+    pio->txf[sm] = clock_get_hz(clk_sys) / (2 * freq);
 }


### PR DESCRIPTION
Added missing parenthesis around the divisor. Verified using a logic analyzer and also in simulation:

https://wokwi.com/arduino/projects/300911723685085709