### PR TITLE
Improve and cleanup cmake config file comments

### DIFF
--- a/blink/CMakeLists.txt
+++ b/blink/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(blink
         blink.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(blink pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/clocks/detached_clk_peri/CMakeLists.txt
+++ b/clocks/detached_clk_peri/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(clocks_detached_clk_peri
         detached_clk_peri.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(clocks_detached_clk_peri pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/clocks/hello_48MHz/CMakeLists.txt
+++ b/clocks/hello_48MHz/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_48MHz
         hello_48MHz.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(hello_48MHz pico_stdlib hardware_clocks)
 
 # create map/bin/hex file etc.

--- a/clocks/hello_48MHz/CMakeLists.txt
+++ b/clocks/hello_48MHz/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_48MHz
         hello_48MHz.c
         )
 
-# pull in common dependencies
+# pull in common dependencies and additional clocks hardware support
 target_link_libraries(hello_48MHz pico_stdlib hardware_clocks)
 
 # create map/bin/hex file etc.

--- a/clocks/hello_gpout/CMakeLists.txt
+++ b/clocks/hello_gpout/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_gpout
         hello_gpout.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(hello_gpout pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/clocks/hello_resus/CMakeLists.txt
+++ b/clocks/hello_resus/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_resus
         hello_resus.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(hello_resus pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/divider/CMakeLists.txt
+++ b/divider/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_divider
         hello_divider.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(hello_divider pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/gpio/hello_7segment/CMakeLists.txt
+++ b/gpio/hello_7segment/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_7segment
         hello_7segment.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(hello_7segment pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/gpio/hello_gpio_irq/CMakeLists.txt
+++ b/gpio/hello_gpio_irq/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_gpio_irq
         hello_gpio_irq.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(hello_gpio_irq pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/hello_world/serial/CMakeLists.txt
+++ b/hello_world/serial/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_serial
         hello_serial.c
         )
 
-# Pull in our pico_stdlib which aggregates commonly used features
+# pull in common dependencies
 target_link_libraries(hello_serial pico_stdlib)
 
 # create map/bin/hex/uf2 file etc.

--- a/hello_world/usb/CMakeLists.txt
+++ b/hello_world/usb/CMakeLists.txt
@@ -3,7 +3,7 @@ if (TARGET tinyusb_device)
             hello_usb.c
             )
 
-    # Pull in our pico_stdlib which aggregates commonly used features
+    # pull in common dependencies
     target_link_libraries(hello_usb pico_stdlib)
 
     # enable usb output, disable uart output

--- a/i2c/bus_scan/CMakeLists.txt
+++ b/i2c/bus_scan/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(i2c_bus_scan
         bus_scan.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional i2c hardware support
 target_link_libraries(i2c_bus_scan pico_stdlib hardware_i2c)
 
 # create map/bin/hex file etc.

--- a/i2c/bus_scan/CMakeLists.txt
+++ b/i2c/bus_scan/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(i2c_bus_scan
         bus_scan.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(i2c_bus_scan pico_stdlib hardware_i2c)
 
 # create map/bin/hex file etc.

--- a/i2c/lcd_1602_i2c/CMakeLists.txt
+++ b/i2c/lcd_1602_i2c/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(lcd_1602_i2c
         lcd_1602_i2c.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional i2c hardware support
 target_link_libraries(lcd_1602_i2c pico_stdlib hardware_i2c)
 
 # create map/bin/hex file etc.

--- a/i2c/lcd_1602_i2c/CMakeLists.txt
+++ b/i2c/lcd_1602_i2c/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(lcd_1602_i2c
         lcd_1602_i2c.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(lcd_1602_i2c pico_stdlib hardware_i2c)
 
 # create map/bin/hex file etc.

--- a/i2c/mpu6050_i2c/CMakeLists.txt
+++ b/i2c/mpu6050_i2c/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(mpu6050_i2c
         mpu6050_i2c.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(mpu6050_i2c pico_stdlib hardware_i2c)
 
 # create map/bin/hex file etc.

--- a/i2c/mpu6050_i2c/CMakeLists.txt
+++ b/i2c/mpu6050_i2c/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(mpu6050_i2c
         mpu6050_i2c.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional i2c hardware support
 target_link_libraries(mpu6050_i2c pico_stdlib hardware_i2c)
 
 # create map/bin/hex file etc.

--- a/i2c/mpu6050_i2c/mpu6050_i2c.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.c
@@ -24,8 +24,8 @@
 
    Connections on Raspberry Pi Pico board, other boards may vary.
 
-   GPIO PICO_DEFAULT_I2C_SDA_PIN (On Pico this is 4 (pin 6)) -> SDA on MPU6050 board
-   GPIO PICO_DEFAULT_I2C_SCK_PIN (On Pico this is 5 (pin 7)) -> SCL on MPU6050 board
+   GPIO PICO_DEFAULT_I2C_SDA_PIN (On Pico this is GP4 (pin 6)) -> SDA on MPU6050 board
+   GPIO PICO_DEFAULT_I2C_SCK_PIN (On Pico this is GP5 (pin 7)) -> SCL on MPU6050 board
    3.3v (pin 36) -> VCC on MPU6050 board
    GND (pin 38)  -> GND on MPU6050 board
 */

--- a/interp/hello_interp/CMakeLists.txt
+++ b/interp/hello_interp/CMakeLists.txt
@@ -3,7 +3,7 @@ if (TARGET hardware_interp)
             hello_interp.c
             )
 
-    # Pull in dependencies
+    # pull in common dependencies and additional interpolation hardware support
     target_link_libraries(hello_interp pico_stdlib hardware_interp)
 
     # create map/bin/hex file etc.

--- a/interp/hello_interp/CMakeLists.txt
+++ b/interp/hello_interp/CMakeLists.txt
@@ -3,7 +3,7 @@ if (TARGET hardware_interp)
             hello_interp.c
             )
 
-    # pull in common dependencies and additional interpolation hardware support
+    # pull in common dependencies and additional interpolator hardware support
     target_link_libraries(hello_interp pico_stdlib hardware_interp)
 
     # create map/bin/hex file etc.

--- a/picoboard/blinky/CMakeLists.txt
+++ b/picoboard/blinky/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(picoboard_blinky
         blinky.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(picoboard_blinky pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/picoboard/button/CMakeLists.txt
+++ b/picoboard/button/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(picoboard_button
         button.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(picoboard_button pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/pwm/hello_pwm/CMakeLists.txt
+++ b/pwm/hello_pwm/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_pwm
         hello_pwm.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies and additional pwm hardware support
 target_link_libraries(hello_pwm pico_stdlib hardware_pwm)
 
 # create map/bin/hex file etc.

--- a/pwm/led_fade/CMakeLists.txt
+++ b/pwm/led_fade/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(pwm_led_fade
         pwm_led_fade.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies and additional pwm hardware support
 target_link_libraries(pwm_led_fade pico_stdlib hardware_pwm)
 
 # create map/bin/hex file etc.

--- a/pwm/measure_duty_cycle/CMakeLists.txt
+++ b/pwm/measure_duty_cycle/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(pwm_measure_duty_cycle
         measure_duty_cycle.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies and additional pwm hardware support
 target_link_libraries(pwm_measure_duty_cycle pico_stdlib hardware_pwm)
 
 # create map/bin/hex file etc.

--- a/reset/CMakeLists.txt
+++ b/reset/CMakeLists.txt
@@ -3,7 +3,7 @@ if (TARGET hardware_reset)
             hello_reset.c
             )
 
-    # Pull in our pico_stdlib which pulls in commonly used features
+    # pull in common dependencies
     target_link_libraries(hello_reset pico_stdlib)
 
     # create map/bin/hex file etc.

--- a/reset/hello_reset/CMakeLists.txt
+++ b/reset/hello_reset/CMakeLists.txt
@@ -3,7 +3,7 @@ if (TARGET hardware_resets)
             hello_reset.c
             )
 
-    # Pull in our pico_stdlib which pulls in commonly used features
+    # pull in common dependencies and additional reset hardware support
     target_link_libraries(hello_reset pico_stdlib hardware_resets)
 
     # create map/bin/hex file etc.

--- a/rtc/hello_rtc/CMakeLists.txt
+++ b/rtc/hello_rtc/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_rtc
         hello_rtc.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional rtc hardware support
 target_link_libraries(hello_rtc pico_stdlib hardware_rtc)
 
 # create map/bin/hex file etc.

--- a/rtc/hello_rtc/CMakeLists.txt
+++ b/rtc/hello_rtc/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_rtc
         hello_rtc.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(hello_rtc pico_stdlib hardware_rtc)
 
 # create map/bin/hex file etc.

--- a/rtc/rtc_alarm/CMakeLists.txt
+++ b/rtc/rtc_alarm/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(rtc_alarm
         rtc_alarm.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(rtc_alarm pico_stdlib hardware_rtc)
 
 # create map/bin/hex file etc.

--- a/rtc/rtc_alarm/CMakeLists.txt
+++ b/rtc/rtc_alarm/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(rtc_alarm
         rtc_alarm.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional rtc hardware support
 target_link_libraries(rtc_alarm pico_stdlib hardware_rtc)
 
 # create map/bin/hex file etc.

--- a/rtc/rtc_alarm_repeat/CMakeLists.txt
+++ b/rtc/rtc_alarm_repeat/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(rtc_alarm_repeat
         rtc_alarm_repeat.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(rtc_alarm_repeat pico_stdlib hardware_rtc)
 
 # create map/bin/hex file etc.

--- a/rtc/rtc_alarm_repeat/CMakeLists.txt
+++ b/rtc/rtc_alarm_repeat/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(rtc_alarm_repeat
         rtc_alarm_repeat.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional rtc hardware support
 target_link_libraries(rtc_alarm_repeat pico_stdlib hardware_rtc)
 
 # create map/bin/hex file etc.

--- a/spi/bme280_spi/CMakeLists.txt
+++ b/spi/bme280_spi/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(bme280_spi
         bme280_spi.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(bme280_spi pico_stdlib hardware_spi)
 
 # create map/bin/hex file etc.

--- a/spi/bme280_spi/CMakeLists.txt
+++ b/spi/bme280_spi/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(bme280_spi
         bme280_spi.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional spi hardware support
 target_link_libraries(bme280_spi pico_stdlib hardware_spi)
 
 # create map/bin/hex file etc.

--- a/spi/mpu9250_spi/CMakeLists.txt
+++ b/spi/mpu9250_spi/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(mpu9250_spi
         mpu9250_spi.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies and additional spi hardware support
 target_link_libraries(mpu9250_spi pico_stdlib hardware_spi)
 
 # create map/bin/hex file etc.

--- a/spi/mpu9250_spi/CMakeLists.txt
+++ b/spi/mpu9250_spi/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(mpu9250_spi
         mpu9250_spi.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(mpu9250_spi pico_stdlib hardware_spi)
 
 # create map/bin/hex file etc.

--- a/spi/spi_flash/CMakeLists.txt
+++ b/spi/spi_flash/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(spi_flash
         spi_flash.c
         )
 
-# Pull in basic dependencies
+# pull in common dependencies and additional spi hardware support
 target_link_libraries(spi_flash pico_stdlib hardware_spi)
 
 # create map/bin/hex file etc.

--- a/system/narrow_io_write/CMakeLists.txt
+++ b/system/narrow_io_write/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(narrow_io_write
         narrow_io_write.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies
 target_link_libraries(narrow_io_write pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/timer/hello_timer/CMakeLists.txt
+++ b/timer/hello_timer/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_timer
         hello_timer.c
         )
 
-# Pull in our get you started dependencies
+# pull in common dependencies
 target_link_libraries(hello_timer pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/timer/hello_timer/CMakeLists.txt
+++ b/timer/hello_timer/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_timer
         hello_timer.c
         )
 
-# Pull in our (to be renamed) simple get you started dependencies
+# Pull in our get you started dependencies
 target_link_libraries(hello_timer pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/timer/periodic_sampler/CMakeLists.txt
+++ b/timer/periodic_sampler/CMakeLists.txt
@@ -3,7 +3,7 @@ if (NOT PICO_TIME_NO_ALARM_SUPPORT)
             periodic_sampler.c
             )
 
-    # Pull in our (to be renamed) simple get you started dependencies
+    # Pull in our get you started dependencies
     target_link_libraries(periodic_sampler pico_stdlib)
 
     # create map/bin/hex file etc.

--- a/timer/periodic_sampler/CMakeLists.txt
+++ b/timer/periodic_sampler/CMakeLists.txt
@@ -3,7 +3,7 @@ if (NOT PICO_TIME_NO_ALARM_SUPPORT)
             periodic_sampler.c
             )
 
-    # Pull in our get you started dependencies
+    # pull in common dependencies
     target_link_libraries(periodic_sampler pico_stdlib)
 
     # create map/bin/hex file etc.

--- a/uart/hello_uart/CMakeLists.txt
+++ b/uart/hello_uart/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_uart
         hello_uart.c
         )
 
-# pull in common dependencies and additional uart hardware support
+# pull in common dependencies
 target_link_libraries(hello_uart pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/uart/hello_uart/CMakeLists.txt
+++ b/uart/hello_uart/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(hello_uart
         hello_uart.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies and additional uart hardware support
 target_link_libraries(hello_uart pico_stdlib)
 
 # create map/bin/hex file etc.

--- a/uart/uart_advanced/CMakeLists.txt
+++ b/uart/uart_advanced/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(uart_advanced
         uart_advanced.c
         )
 
-# Pull in our pico_stdlib which pulls in commonly used features
+# pull in common dependencies and additional uart hardware support
 target_link_libraries(uart_advanced pico_stdlib hardware_uart)
 
 # create map/bin/hex file etc.


### PR DESCRIPTION
Two improvements from the examples written so far:

* remove the "to be renamed" line 
* Add "GP" to clarify the pins in question are GPIO numbered