### PR TITLE
Consider filter drop for Vref and use max ADC as 2^12 - 1

### DIFF
--- a/adc/hello_adc/hello_adc.c
+++ b/adc/hello_adc/hello_adc.c
@@ -21,8 +21,10 @@ int main() {
     adc_select_input(0);
 
     while (1) {
-        // 12-bit conversion, assume max value == ADC_VREF == 3.3 V
-        const float conversion_factor = 3.3f / (1 << 12);
+        // 12-bit conversion, assume max value == ADC_VREF == 3.3 V minus 34 mV filter drop,
+        // for an unclamped ADC_VREF pin. 
+        const float adc_vref = 3.266f; // change to 3.0 when clamped with LM4040 3.0V external shunt reference
+        const float conversion_factor = adc_vref / 4095; // max ADC is 2^12 - 1
         uint16_t result = adc_read();
         printf("Raw value: 0x%03x, voltage: %f V\n", result, result * conversion_factor);
         sleep_ms(500);


### PR DESCRIPTION
Pico datasheet, 4.3. Using the ADC: "The ADC draws current (about 150μA if the temperature sense diode is disabled, but it varies from chip to chip) and therefore there will be an inherent offset of about 150μA*200 = ~30mV. There is a small difference in current draw when the ADC is sampling (about +20μA)"
Thus when sampling Vref is nominal (150+20)μA*200 = ~34mV

Splitting the variable in two lines makes the change for the clamped situation more intuitive. 

The value range of a 12 bit resolution is 0-4095, i.e. 2^12 minus one.