### PR TITLE
Add example for MPL3115A2 altimeter

### DIFF
--- a/i2c/CMakeLists.txt
+++ b/i2c/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (NOT PICO_NO_HARDWARE)
     add_subdirectory(bus_scan)
     add_subdirectory(lcd_1602_i2c)
+    add_subdirectory(mpl3115a2_i2c)
     add_subdirectory(mpu6050_i2c)
 endif ()

--- a/i2c/mpl3115a2_i2c/CMakeLists.txt
+++ b/i2c/mpl3115a2_i2c/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(mpl3115a2_i2c
+        mpl3115a2_i2c.c
+        )
+
+# pull in common dependencies and additional i2c hardware support
+target_link_libraries(mpl3115a2_i2c pico_stdlib hardware_i2c)
+
+# create map/bin/hex file etc.
+pico_add_extra_outputs(mpl3115a2_i2c)
+
+# add url via pico_set_program_url
+example_auto_set_url(mpl3115a2_i2c)

--- a/i2c/mpl3115a2_i2c/README.adoc
+++ b/i2c/mpl3115a2_i2c/README.adoc
@@ -1,0 +1,28 @@
+= Attaching an MPL3115A2 altimeter via I2C
+
+== Wiring information
+
+Wiring up the device requires 4 jumpers, to connect VCC (3.3v), GND, SDA and SCL. The example here uses I2C port 0, which is assigned to GPIO 4 (SDA) and GPIO 5 (SCL) by default. Power is supplied from the 3.3V pin.
+
+[[mpl3115a2_i2c_wiring]]
+[pdfwidth=75%]
+.Wiring Diagram for MPL3115A2 altimeter.
+image::mpl3115a2_i2c_bb.png[]
+
+== List of Files
+
+CMakeLists.txt:: CMake file to incorporate the example in to the examples build tree.
+mpl3115a2_i2c.c:: The example code.
+
+== Bill of Materials
+
+.A list of materials required for the example
+[[mpl3115a2-i2c-bom-table]]
+[cols=3]
+|===
+| *Item* | *Quantity* | Details
+| Breadboard | 1 | generic part
+| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| MPL3115A2 altimeter | 1 | https://www.adafruit.com/product/1893[Adafruit]
+| M/M Jumper wires | 5 | generic part
+|===

--- a/i2c/mpl3115a2_i2c/mpl3115a2_i2c.c
+++ b/i2c/mpl3115a2_i2c/mpl3115a2_i2c.c
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/stdlib.h"
+#include "pico/binary_info.h"
+#include "hardware/i2c.h"


### PR DESCRIPTION
This PR adds an example for the MPL3115A2 altimeter with absolute pressure + temp sensor. To add some variety to the pressure/temp sea of sensors, this example demonstrates some of the more advanced features of this board and its different modes.

## Checklist

- []  documentation
- [] working example
- [] Fritzing schematic and image
- [x] added to CMakeLists.txt
- [] added to repo README