### PR TITLE
Add example for 16x2 RGB LCD display with TTL backpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ App|Description
 App|Description
 ---|---
 [hello_uart](uart/hello_uart) | Print some text from one of the UART serial ports, without going through `stdio`.
+[lcd_uart](uart/lcd_uart) | Display text and symbols on a 16x02 RGB LCD display via UART
 [uart_advanced](uart/uart_advanced) | Use some other UART features like RX interrupts, hardware control flow, and data formats other than 8n1.
 
 ### USB Device

--- a/uart/CMakeLists.txt
+++ b/uart/CMakeLists.txt
@@ -1,4 +1,5 @@
 if (NOT PICO_NO_HARDWARE)
     add_subdirectory(hello_uart)
+    add_subdirectory(lcd_uart)
     add_subdirectory(uart_advanced)
 endif ()

--- a/uart/lcd_uart/CMakeLists.txt
+++ b/uart/lcd_uart/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(lcd_uart
+        lcd_uart.c
+        )
+
+# pull in common dependencies and additional uart hardware support
+target_link_libraries(lcd_uart pico_stdlib hardware_uart)
+
+# create map/bin/hex file etc.
+pico_add_extra_outputs(lcd_uart)
+
+# add url via pico_set_program_url
+example_auto_set_url(lcd_uart)

--- a/uart/lcd_uart/lcd_uart.c
+++ b/uart/lcd_uart/lcd_uart.c
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "hardware/uart.h"
+
+// leave uart0 free for stdio
+#define UART_ID uart1
+#define BAUD_RATE 9600
+#define UART_TX_PIN 8
+
+int main() {
+    stdio_init_all();
+    // Set up our UART with the required speed.
+    uart_init(UART_ID, BAUD_RATE);
+
+    // Set the TX and RX pins by using the function select on the GPIO
+    // Set datasheet for more information on function select
+    gpio_set_function(UART_TX_PIN, GPIO_FUNC_UART);
+}


### PR DESCRIPTION
This PR adds an example for a 16x2 RGB LCD display with a TTL backpack from Adafruit that comes with a simple command set. 

## Checklist

- [ ]  documentation
- [ ] working example
- [ ] Fritzing schematic and image
- [x] added to CMakeLists.txt
- [x] added to repo README