### PR TITLE
bus_scan.c example - fix pin number in comment

### DIFF
--- a/i2c/bus_scan/bus_scan.c
+++ b/i2c/bus_scan/bus_scan.c
@@ -38,7 +38,7 @@ int main() {
 #warning i2c/bus_scan example requires a board with I2C pins
     puts("Default I2C pins were not defined");
 #else
-    // This example will use I2C0 on the default SDA and SCL pins (4, 5 on a Pico)
+    // This example will use I2C0 on the default SDA and SCL pins (6, 7 on a Pico)
     i2c_init(i2c_default, 100 * 1000);
     gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
     gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);

--- a/i2c/bus_scan/bus_scan.c
+++ b/i2c/bus_scan/bus_scan.c
@@ -38,7 +38,7 @@ int main() {
 #warning i2c/bus_scan example requires a board with I2C pins
     puts("Default I2C pins were not defined");
 #else
-    // This example will use I2C0 on the default SDA and SCL pins (6, 7 on a Pico)
+    // This example will use I2C0 on the default SDA and SCL pins (GP4, GP5 on a Pico)
     i2c_init(i2c_default, 100 * 1000);
     gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
     gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);


### PR DESCRIPTION
The comment in the code is incorrect. I tested this out, and it doesn't detect the device via those pins.

I was searching and found this comment thread: https://www.raspberrypi.org/forums/viewtopic.php?p=1822258&sid=1ff96911779abcedda7b3ae535d1d0af#p1822258

Sure enough, when I switched to pins 6 and 7, the code worked fine and could detect the device I had plugged into the i2c bus.

```
I2C Bus Scan
   0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
00 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
10 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
20 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
30 .  .  .  .  .  .  .  .  .  .  .  .  @  .  .  .
40 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
50 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
60 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
70 .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
Done.
```

Example wiring.

![pico](https://user-images.githubusercontent.com/1029947/126869798-9b3bceb9-62d4-49cf-a233-a4d3830e16df.png)
