### PR TITLE
Update website-links to raspberrypi.com

### DIFF
--- a/gpio/dht_sensor/README.adoc
+++ b/gpio/dht_sensor/README.adoc
@@ -51,7 +51,7 @@ dht.c:: The example code.
 |===
 | *Item* | *Quantity* | Details
 | Breadboard | 1 | generic part
-| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| Raspberry Pi Pico | 1 | https://www.raspberrypi.com/
 | 10 kΩ resistor | 1 | generic part
 | M/M Jumper wires | 4 | generic part
 | DHT-22 sensor | 1 | generic part

--- a/gpio/hello_7segment/README.adoc
+++ b/gpio/hello_7segment/README.adoc
@@ -40,7 +40,7 @@ hello_7segment.c:: The example code.
 |===
 | *Item* | *Quantity* | Details
 | Breadboard | 1 | generic part
-| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| Raspberry Pi Pico | 1 | https://www.raspberrypi.com/
 | 7 segment LED module | 1 | generic part
 | 68 ohm resistor | 7 | generic part
 | DIL push to make switch | 1 | generic switch

--- a/i2c/lcd_1602_i2c/README.adoc
+++ b/i2c/lcd_1602_i2c/README.adoc
@@ -32,7 +32,7 @@ lcd_1602_i2c.c:: The example code.
 |===
 | *Item* | *Quantity* | Details
 | Breadboard | 1 | generic part
-| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| Raspberry Pi Pico | 1 | https://www.raspberrypi.com/
 | 1602A based LCD panel 3.3v | 1 | generic part
 | 1602A to I2C bridge device 3.3v | 1 | generic part
 | M/M Jumper wires | 4 | generic part

--- a/i2c/mpu6050_i2c/README.adoc
+++ b/i2c/mpu6050_i2c/README.adoc
@@ -35,7 +35,7 @@ mpu6050_i2c.c:: The example code.
 |===
 | *Item* | *Quantity* | Details
 | Breadboard | 1 | generic part
-| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| Raspberry Pi Pico | 1 | https://www.raspberrypi.com/
 | MPU6050 board| 1 | generic part
 | M/M Jumper wires | 4 | generic part
 |===

--- a/spi/bme280_spi/README.adoc
+++ b/spi/bme280_spi/README.adoc
@@ -42,7 +42,7 @@ bme280_spi.c:: The example code.
 |===
 | *Item* | *Quantity* | Details
 | Breadboard | 1 | generic part
-| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| Raspberry Pi Pico | 1 | https://www.raspberrypi.com/
 | BME280 board| 1 | generic part
 | M/M Jumper wires | 6 | generic part
 |===

--- a/spi/mpu9250_spi/README.adoc
+++ b/spi/mpu9250_spi/README.adoc
@@ -44,7 +44,7 @@ mpu9250_spi.c:: The example code.
 |===
 | *Item* | *Quantity* | Details
 | Breadboard | 1 | generic part
-| Raspberry Pi Pico | 1 | http://raspberrypi.org/
+| Raspberry Pi Pico | 1 | https://www.raspberrypi.com/
 | MPU9250 board| 1 | generic part
 | M/M Jumper wires | 6 | generic part
 |===


### PR DESCRIPTION
@aallan Do we want to leave these URLs as https://www.raspberrypi.com/ or would https://www.raspberrypi.com/products/raspberry-pi-pico/ be better?

@JamesH65 I guess you'll need to do something similar for the intern's PRs?