### PR TITLE
Fix for when uart_default isn't defined

### DIFF
--- a/uart/lcd_uart/lcd_uart.c
+++ b/uart/lcd_uart/lcd_uart.c
@@ -156,7 +156,7 @@ int main() {
 
     while (1) {
         // send any chars from stdio straight to the backpack
-        char c = uart_getc(uart_default);
+        char c = uart_getc(UART_ID);
         // any bytes not followed by 0xFE (the special command) are interpreted
         // as text to be displayed on the backpack, so we just send the char
         // down the UART byte pipe!


### PR DESCRIPTION
@kilograham AFAICT this is the last remaining change needed for #176 so that `pico-examples` builds with `-DPICO_BOARD=none` set.