### PR TITLE
PIO Quadrature fixes

### DIFF
--- a/pio/quadrature_encoder/quadrature_encoder.pio
+++ b/pio/quadrature_encoder/quadrature_encoder.pio
@@ -112,7 +112,6 @@ increment_cont:
 static inline void quadrature_encoder_program_init(PIO pio, uint sm, uint offset, uint pin, int max_step_rate)
 {
 	pio_sm_set_consecutive_pindirs(pio, sm, pin, 2, false);
-	pio_gpio_init(pio, pin);
 	gpio_pull_up(pin);
 	gpio_pull_up(pin + 1);
 

--- a/pio/quadrature_encoder/quadrature_encoder.pio
+++ b/pio/quadrature_encoder/quadrature_encoder.pio
@@ -114,6 +114,7 @@ static inline void quadrature_encoder_program_init(PIO pio, uint sm, uint offset
 	pio_sm_set_consecutive_pindirs(pio, sm, pin, 2, false);
 	pio_gpio_init(pio, pin);
 	gpio_pull_up(pin);
+	gpio_pull_up(pin + 1);
 
 	pio_sm_config c = quadrature_encoder_program_get_default_config(offset);
 	sm_config_set_in_pins(&c, pin); // for WAIT, IN


### PR DESCRIPTION
- Enable internal pull up on B-phase pin too.
- pio_gpio_init is not needed for input.