### PR TITLE
ir_nec: fix a minor clock setup typo in nec_receive.pio

### DIFF
--- a/pio/ir_nec/nec_receive_library/nec_receive.pio
+++ b/pio/ir_nec/nec_receive_library/nec_receive.pio
@@ -82,7 +82,7 @@ static inline void nec_receive_program_init (PIO pio, uint sm, uint offset, uint
 
     // Set the clock divider to 10 ticks per 562.5us burst period
     //
-    float div = clock_get_hz (clk_sys) / (10.0 / 526.6e-6);
+    float div = clock_get_hz (clk_sys) / (10.0 / 562.5e-6);
     sm_config_set_clkdiv (&c, div);
 
     // Apply the configuration to the state machine


### PR DESCRIPTION
Fixes #206 - reference that for more detail.