### PR TITLE
Add delay to hello_rtc (#109)

### DIFF
--- a/rtc/hello_rtc/hello_rtc.c
+++ b/rtc/hello_rtc/hello_rtc.c
@@ -32,6 +32,10 @@ int main() {
     rtc_init();
     rtc_set_datetime(&t);
 
+    // clk_sys is >2000x faster than clk_rtc, so datetime is not updated immediately when rtc_get_datetime() is called.
+    // tbe delay is up to 3 RTC clock cycles (which is 64us with the default clock settings)
+    sleep_us(64);
+
     // Print the time
     while (true) {
         rtc_get_datetime(&t);


### PR DESCRIPTION
A delay is needed after `rtc_set_datetime()` before the newly set value can be read back.