### PR TITLE
fix typos in pico-w examples

### DIFF
--- a/pico_w/freertos/iperf/picow_freertos_iperf.c
+++ b/pico_w/freertos/iperf/picow_freertos_iperf.c
@@ -120,7 +120,7 @@ int main( void )
 #if ( portSUPPORT_SMP == 1 ) && ( configNUM_CORES == 2 )
     printf("Starting %s on both cores:\n", rtos_name);
     vLaunch();
-#elif ( RUN_FREE_RTOS_ON_CORE == 1 )
+#elif ( RUN_FREERTOS_ON_CORE == 1 )
     printf("Starting %s on core 1:\n", rtos_name);
     multicore_launch_core1(vLaunch);
     while (true);

--- a/pico_w/freertos/ping/picow_freertos_ping.c
+++ b/pico_w/freertos/ping/picow_freertos_ping.c
@@ -78,7 +78,7 @@ int main( void )
 #if ( portSUPPORT_SMP == 1 ) && ( configNUM_CORES == 2 )
     printf("Starting %s on both cores:\n", rtos_name);
     vLaunch();
-#elif ( RUN_FREE_RTOS_ON_CORE == 1 )
+#elif ( RUN_FREERTOS_ON_CORE == 1 )
     printf("Starting %s on core 1:\n", rtos_name);
     multicore_launch_core1(vLaunch);
     while (true);


### PR DESCRIPTION
The Pico W ping and iperf examples define [RUN_FREERTOS_ON_CORE](https://github.com/raspberrypi/pico-examples/blob/sdk-1.4.0/pico_w/freertos/ping/picow_freertos_ping.c#L20) but later refer to [RUN_FREE_RTOS_ON_CORE](https://github.com/raspberrypi/pico-examples/blob/sdk-1.4.0/pico_w/freertos/ping/picow_freertos_ping.c#L81). This PR fixes those typos.