### PR TITLE
Use the flash chip ID as the USB serial number

### DIFF
--- a/usb/device/dev_hid_composite/CMakeLists.txt
+++ b/usb/device/dev_hid_composite/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(dev_hid_composite PUBLIC
 
 # In addition to pico_stdlib required for common PicoSDK functionality, add dependency on tinyusb_device
 # for TinyUSB device support and tinyusb_board for the additional board support library used by the example
-target_link_libraries(dev_hid_composite PUBLIC pico_stdlib tinyusb_device tinyusb_board)
+target_link_libraries(dev_hid_composite PUBLIC pico_stdlib pico_unique_id tinyusb_device tinyusb_board)
 
 # Uncomment this line to enable fix for Errata RP2040-E5 (the fix requires use of GPIO 15)
 #target_compile_definitions(dev_hid_composite PUBLIC PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1)

--- a/usb/device/dev_hid_composite/usb_descriptors.c
+++ b/usb/device/dev_hid_composite/usb_descriptors.c
@@ -178,7 +178,7 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 // String Descriptors
 //--------------------------------------------------------------------+
 
-// buffer to hold flash chip id
+// buffer to hold flash ID
 char serial[2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1];
 
 // array of pointer to string descriptors
@@ -187,7 +187,7 @@ char const* string_desc_arr [] =
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "TinyUSB",                     // 1: Manufacturer
   "TinyUSB Device",              // 2: Product
-  serial,                        // 3: Serials, should use chip ID
+  serial,                        // 3: Serials, uses the flash ID
 };
 
 static uint16_t _desc_str[32];

--- a/usb/device/dev_hid_composite/usb_descriptors.c
+++ b/usb/device/dev_hid_composite/usb_descriptors.c
@@ -23,6 +23,7 @@
  *
  */
 
+#include "pico/unique_id.h"
 #include "tusb.h"
 #include "usb_descriptors.h"
 
@@ -177,13 +178,16 @@ uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
 // String Descriptors
 //--------------------------------------------------------------------+
 
+// buffer to hold flash chip id
+char serial[2 * PICO_UNIQUE_BOARD_ID_SIZE_BYTES + 1];
+
 // array of pointer to string descriptors
 char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "TinyUSB",                     // 1: Manufacturer
   "TinyUSB Device",              // 2: Product
-  "123456",                      // 3: Serials, should use chip ID
+  serial,                        // 3: Serials, should use chip ID
 };
 
 static uint16_t _desc_str[32];
@@ -205,6 +209,8 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
     // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 
+    if (index == 3) pico_get_unique_board_id_string(serial, sizeof(serial));
+    
     if ( !(index < sizeof(string_desc_arr)/sizeof(string_desc_arr[0])) ) return NULL;
 
     const char* str = string_desc_arr[index];


### PR DESCRIPTION
Simple change to use the flash chip ID as the USB serial number with the TinyUSB example. I can squash/rebase as needed.