### PR TITLE
Add iperf client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ App|Description
 ---|---
 [picow_access_point](pico_w/access_point)| Starts a WiFi access point, and fields DHCP requests.
 [picow_blink](pico_w/blink)| Blinks the on-board LED (which is connected via the WiFi chip).
-[picow_iperf_server](pico_w/iperf)| Runs an "iperf" server for WiFi speed testing.
+[picow_iperf](pico_w/iperf)| Runs an "iperf" as server or client for WiFi speed testing.
 [picow_ntp_client](pico_w/ntp_client)| Connects to an NTP server to fetch and display the current time.
 [picow_tcp_client](pico_w/tcp_client)| A simple TCP client. You can run [python_test_tcp_server.py](pico_w/python_test_tcp/python_test_tcp_server.py) for it to connect to.
 [picow_tcp_server](pico_w/tcp_server)| A simple TCP server. You can use [python_test_tcp_client.py](pico_w/python_test_tcp/python_test_tcp_client.py) to connect to it.

--- a/pico_w/freertos/iperf/CMakeLists.txt
+++ b/pico_w/freertos/iperf/CMakeLists.txt
@@ -1,38 +1,59 @@
-add_executable(picow_freertos_iperf_server_nosys
-        picow_freertos_iperf.c
+add_library(picow_freertos_iperf_common INTERFACE)
+target_sources(picow_freertos_iperf_common INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/picow_freertos_iperf.c
         )
-target_compile_definitions(picow_freertos_iperf_server_nosys PRIVATE
+target_compile_definitions(picow_freertos_iperf_common INTERFACE
         WIFI_SSID=\"${WIFI_SSID}\"
         WIFI_PASSWORD=\"${WIFI_PASSWORD}\"
         )
-target_include_directories(picow_freertos_iperf_server_nosys PRIVATE
+target_include_directories(picow_freertos_iperf_common INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/../.. # for our common lwipopts
         )
-target_link_libraries(picow_freertos_iperf_server_nosys
-        pico_cyw43_arch_lwip_threadsafe_background
+target_link_libraries(picow_freertos_iperf_common INTERFACE
         pico_stdlib
         pico_lwip_iperf
         FreeRTOS-Kernel-Heap4 # FreeRTOS kernel and dynamic heap
+        )
+
+add_executable(picow_freertos_iperf_server_nosys)
+target_link_libraries(picow_freertos_iperf_server_nosys
+        pico_cyw43_arch_lwip_threadsafe_background
+        picow_freertos_iperf_common
         )
 pico_add_extra_outputs(picow_freertos_iperf_server_nosys)
 
-add_executable(picow_freertos_iperf_server_sys
-        picow_freertos_iperf.c
-        )
+add_executable(picow_freertos_iperf_server_sys)
 target_compile_definitions(picow_freertos_iperf_server_sys PRIVATE
-        WIFI_SSID=\"${WIFI_SSID}\"
-        WIFI_PASSWORD=\"${WIFI_PASSWORD}\"
         NO_SYS=0            # don't want NO_SYS (generally this would be in your lwipopts.h)
-        )
-target_include_directories(picow_freertos_iperf_server_sys PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}
-        ${CMAKE_CURRENT_LIST_DIR}/../.. # for our common lwipopts
         )
 target_link_libraries(picow_freertos_iperf_server_sys
         pico_cyw43_arch_lwip_sys_freertos
-        pico_stdlib
-        pico_lwip_iperf
-        FreeRTOS-Kernel-Heap4 # FreeRTOS kernel and dynamic heap
+        picow_freertos_iperf_common
         )
 pico_add_extra_outputs(picow_freertos_iperf_server_sys)
+
+if(IPERF_SERVER_IP)
+        add_executable(picow_freertos_iperf_client_nosys)
+        target_compile_definitions(picow_freertos_iperf_client_nosys PRIVATE
+                IPERF_SERVER_IP=\"${IPERF_SERVER_IP}\"
+                IPERF_CLIENT=1
+                )
+        target_link_libraries(picow_freertos_iperf_client_nosys
+                pico_cyw43_arch_lwip_threadsafe_background
+                picow_freertos_iperf_common
+                )
+        pico_add_extra_outputs(picow_freertos_iperf_client_nosys)
+
+        add_executable(picow_freertos_iperf_client_sys)
+        target_compile_definitions(picow_freertos_iperf_client_sys PRIVATE
+                NO_SYS=0            # don't want NO_SYS (generally this would be in your lwipopts.h)
+                IPERF_SERVER_IP=\"${IPERF_SERVER_IP}\"
+                IPERF_CLIENT=1
+                )
+        target_link_libraries(picow_freertos_iperf_client_sys
+                pico_cyw43_arch_lwip_sys_freertos
+                picow_freertos_iperf_common
+                )
+        pico_add_extra_outputs(picow_freertos_iperf_client_sys)
+endif()

--- a/pico_w/freertos/iperf/picow_freertos_iperf.c
+++ b/pico_w/freertos/iperf/picow_freertos_iperf.c
@@ -21,7 +21,7 @@
 #define TEST_TASK_PRIORITY				( tskIDLE_PRIORITY + 2UL )
 #define BLINK_TASK_PRIORITY				( tskIDLE_PRIORITY + 1UL )
 
-#if CLIENT_TEST && !defined(IPERF_SERVER_IP)
+#if IPERF_CLIENT && !defined(IPERF_SERVER_IP)
 #error IPERF_SERVER_IP not defined
 #endif
 
@@ -72,10 +72,10 @@ void main_task(__unused void *params) {
 
     xTaskCreate(blink_task, "BlinkThread", configMINIMAL_STACK_SIZE, NULL, BLINK_TASK_PRIORITY, NULL);
 
-#if CLIENT_TEST
-    printf("\nReady, running iperf client\n");
+#if IPERF_CLIENT
     ip_addr_t clientaddr;
-    ip4_addr_set_u32(&clientaddr, ipaddr_addr(xstr(IPERF_SERVER_IP)));
+    ip4_addr_set_u32(&clientaddr, ipaddr_addr(IPERF_SERVER_IP));
+    printf("\nReady, running iperf from client %s to server %s\n", ip4addr_ntoa(netif_ip4_addr(netif_list)), IPERF_SERVER_IP);
     assert(lwiperf_start_tcp_client_default(&clientaddr, &iperf_report, NULL) != NULL);
 #else
     printf("\nReady, running iperf server at %s\n", ip4addr_ntoa(netif_ip4_addr(netif_list)));

--- a/pico_w/iperf/CMakeLists.txt
+++ b/pico_w/iperf/CMakeLists.txt
@@ -1,37 +1,57 @@
-add_executable(picow_iperf_server_background
-        picow_iperf.c
+add_library(picow_iperf_common INTERFACE)
+target_sources(picow_iperf_common INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/picow_iperf.c
         )
-target_compile_definitions(picow_iperf_server_background PRIVATE
+target_compile_definitions(picow_iperf_common INTERFACE
         WIFI_SSID=\"${WIFI_SSID}\"
         WIFI_PASSWORD=\"${WIFI_PASSWORD}\"
         )
-target_include_directories(picow_iperf_server_background PRIVATE
+target_include_directories(picow_iperf_common INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}
         ${CMAKE_CURRENT_LIST_DIR}/.. # for our common lwipopts
         )
+target_link_libraries(picow_iperf_common INTERFACE
+        pico_stdlib
+        pico_lwip_iperf
+        )
+
+add_executable(picow_iperf_server_background)
 target_link_libraries(picow_iperf_server_background
         pico_cyw43_arch_lwip_threadsafe_background
-        pico_stdlib
-        pico_lwip_iperf
+        picow_iperf_common
         )
-
 pico_add_extra_outputs(picow_iperf_server_background)
 
-add_executable(picow_iperf_server_poll
-        picow_iperf.c
-        )
-target_compile_definitions(picow_iperf_server_poll PRIVATE
-        WIFI_SSID=\"${WIFI_SSID}\"
-        WIFI_PASSWORD=\"${WIFI_PASSWORD}\"
-        )
-target_include_directories(picow_iperf_server_poll PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}
-        ${CMAKE_CURRENT_LIST_DIR}/.. # for our common lwipopts
-        )
+add_executable(picow_iperf_server_poll)
 target_link_libraries(picow_iperf_server_poll
         pico_cyw43_arch_lwip_poll
-        pico_stdlib
-        pico_lwip_iperf
+        picow_iperf_common
         )
 pico_add_extra_outputs(picow_iperf_server_poll)
 
+# Add iperf client examples
+if(NOT IPERF_SERVER_IP)
+        message("Skipping iperf client examples as IPERF_SERVER_IP is not defined")
+else()
+        add_executable(picow_iperf_client_background)
+        target_compile_definitions(picow_iperf_client_background PRIVATE
+                IPERF_SERVER_IP=\"${IPERF_SERVER_IP}\"
+                IPERF_CLIENT=1
+                )
+        target_link_libraries(picow_iperf_client_background
+                pico_cyw43_arch_lwip_threadsafe_background
+                picow_iperf_common
+                )
+        pico_add_extra_outputs(picow_iperf_client_background)
+
+        add_executable(picow_iperf_client_poll)
+        target_compile_definitions(picow_iperf_client_poll PRIVATE
+                IPERF_SERVER_IP=\"${IPERF_SERVER_IP}\"
+                IPERF_CLIENT=1
+                )
+        target_link_libraries(picow_iperf_client_poll
+                pico_cyw43_arch_lwip_poll
+                picow_iperf_common
+                )
+        pico_add_extra_outputs(picow_iperf_client_poll)
+endif()

--- a/pico_w/iperf/picow_iperf.c
+++ b/pico_w/iperf/picow_iperf.c
@@ -15,7 +15,7 @@
 #define USE_LED 1
 #endif
 
-#if CLIENT_TEST && !defined(IPERF_SERVER_IP)
+#if IPERF_CLIENT && !defined(IPERF_SERVER_IP)
 #error IPERF_SERVER_IP not defined
 #endif
 
@@ -38,7 +38,6 @@ static void iperf_report(void *arg, enum lwiperf_report_type report_type,
 
 int main() {
     stdio_init_all();
-
     if (cyw43_arch_init()) {
         printf("failed to initialise\n");
         return 1;
@@ -52,10 +51,10 @@ int main() {
         printf("Connected.\n");
     }
 
-#if CLIENT_TEST
-    printf("\nReady, running iperf client\n");
+#if IPERF_CLIENT
     ip_addr_t clientaddr;
-    ip4_addr_set_u32(&clientaddr, ipaddr_addr(xstr(IPERF_SERVER_IP)));
+    ip4_addr_set_u32(&clientaddr, ipaddr_addr(IPERF_SERVER_IP));
+    printf("\nReady, running iperf from client %s to server %s\n", ip4addr_ntoa(netif_ip4_addr(netif_list)), IPERF_SERVER_IP);
     assert(lwiperf_start_tcp_client_default(&clientaddr, &iperf_report, NULL) != NULL);
 #else
     printf("\nReady, running iperf server at %s\n", ip4addr_ntoa(netif_ip4_addr(netif_list)));


### PR DESCRIPTION
Requires you to specify the server ip address when running cmake,
e.g. -DIPERF_SERVER_IP=1.2.3.4

Fixes #255