### PR TITLE
wifi scan: Enable USB output

### DIFF
--- a/pico_w/wifi_scan/CMakeLists.txt
+++ b/pico_w/wifi_scan/CMakeLists.txt
@@ -25,3 +25,6 @@ target_link_libraries(picow_wifi_scan_poll
         )
 pico_add_extra_outputs(picow_wifi_scan_poll)
 
+pico_enable_stdio_usb(picow_wifi_scan_background 1)
+pico_enable_stdio_usb(picow_wifi_scan_poll 1)
+


### PR DESCRIPTION
It tripped me up that these examples required the use of a serial adapter, rather than working via usb serial.