### PR TITLE
Fix missing TCP_PORT for printf in TCP server example

### DIFF
--- a/pico_w/tcp_server/picow_tcp_server.c
+++ b/pico_w/tcp_server/picow_tcp_server.c
@@ -197,7 +197,7 @@ static bool tcp_server_open(void *arg) {
 
     err_t err = tcp_bind(pcb, NULL, TCP_PORT);
     if (err) {
-        DEBUG_printf("failed to bind to port %d\n");
+        DEBUG_printf("failed to bind to port %u\n", TCP_PORT);
         return false;
     }
 


### PR DESCRIPTION
Also replace `%d` with `%u`