### PR TITLE
fixed issue with macOS for usb device dev_lowlevel example

### DIFF
--- a/usb/device/dev_lowlevel/dev_lowlevel.c
+++ b/usb/device/dev_lowlevel/dev_lowlevel.c
@@ -264,13 +264,13 @@ void usb_start_transfer(struct usb_endpoint_configuration *ep, uint8_t *buf, uin
  * @brief Send device descriptor to host
  *
  */
-void usb_handle_device_descriptor(void) {
+void usb_handle_device_descriptor(volatile struct usb_setup_packet *pkt) {
     const struct usb_device_descriptor *d = dev_config.device_descriptor;
     // EP0 in
     struct usb_endpoint_configuration *ep = usb_get_endpoint_configuration(EP0_IN_ADDR);
     // Always respond with pid 1
     ep->next_pid = 1;
-    usb_start_transfer(ep, (uint8_t *) d, sizeof(struct usb_device_descriptor));
+    usb_start_transfer(ep, (uint8_t *) d, MIN(sizeof(struct usb_device_descriptor), pkt->wLength));
 }
 
 /**
@@ -305,7 +305,7 @@ void usb_handle_config_descriptor(volatile struct usb_setup_packet *pkt) {
     // Send data
     // Get len by working out end of buffer subtract start of buffer
     uint32_t len = (uint32_t) buf - (uint32_t) &ep0_buf[0];
-    usb_start_transfer(usb_get_endpoint_configuration(EP0_IN_ADDR), &ep0_buf[0], len);
+    usb_start_transfer(usb_get_endpoint_configuration(EP0_IN_ADDR), &ep0_buf[0], MIN(len, pkt->wLength));
 }
 
 /**
@@ -337,7 +337,7 @@ void usb_handle_string_descriptor(volatile struct usb_setup_packet *pkt) {
         len = usb_prepare_string_descriptor(dev_config.descriptor_strings[i - 1]);
     }
 
-    usb_start_transfer(usb_get_endpoint_configuration(EP0_IN_ADDR), &ep0_buf[0], len);
+    usb_start_transfer(usb_get_endpoint_configuration(EP0_IN_ADDR), &ep0_buf[0], MIN(len, pkt->wLength));
 }
 
 /**
@@ -404,7 +404,7 @@ void usb_handle_setup_packet(void) {
 
             switch (descriptor_type) {
                 case USB_DT_DEVICE:
-                    usb_handle_device_descriptor();
+                    usb_handle_device_descriptor(pkt);
                     printf("GET DEVICE DESCRIPTOR\r\n");
                     break;
 


### PR DESCRIPTION
The usb/device/dev_lowlevel example does not work on macOS, showing a device enumeration error. The error occurs because more data is being sent than was requested.