### PR TITLE
Corrects define name on OLED i2c Example

### DIFF
--- a/i2c/oled_i2c/oled_i2c.c
+++ b/i2c/oled_i2c/oled_i2c.c
@@ -24,7 +24,7 @@
 
    GPIO PICO_DEFAULT_I2C_SDA_PIN (on Pico this is GP4 (pin 6)) -> SDA on display
    board
-   GPIO PICO_DEFAULT_I2C_SCK_PIN (on Pico this is GP5 (pin 7)) -> SCL on
+   GPIO PICO_DEFAULT_I2C_SCL_PIN (on Pico this is GP5 (pin 7)) -> SCL on
    display board
    3.3v (pin 36) -> VCC on display board
    GND (pin 38)  -> GND on display board


### PR DESCRIPTION
Corrects `PICO_DEFAULT_I2C_SCL_PIN` instead of `PICO_DEFAULT_I2C_SCK_PIN` in the docs - off by one letter