### PR TITLE
Pico-W Access Point: Fix DHCP server for certain clients (dhcpcd)

### DIFF
--- a/pico_w/access_point/dhcpserver/dhcpserver.c
+++ b/pico_w/access_point/dhcpserver/dhcpserver.c
@@ -200,7 +200,13 @@ static void dhcp_server_process(void *arg, struct udp_pcb *upcb, struct pbuf *p,
     uint8_t *opt = (uint8_t *)&dhcp_msg.options;
     opt += 4; // assume magic cookie: 99, 130, 83, 99
 
-    switch (opt[2]) {
+    uint8_t *msgtype = opt_find(opt, DHCP_OPT_MSG_TYPE);
+    if (msgtype == NULL) {
+        // A DHCP package without MSG_TYPE?
+        goto ignore_request;
+    }
+
+    switch (msgtype[2]) {
         case DHCPDISCOVER: {
             int yi = DHCPS_MAX_IP;
             for (int i = 0; i < DHCPS_MAX_IP; ++i) {


### PR DESCRIPTION
See https://github.com/hathach/tinyusb/pull/1712 and the initial trigger https://github.com/OpenLightingProject/rp2040-dmxsun/issues/53:

The included DHCP server fails to process DHCP DISCOVER or REQUEST packages that don't contain the "DHCP MESSAGE TYPE" option as the first option in the package.
The initial report that triggered me was in https://github.com/OpenLightingProject/rp2040-dmxsun/issues/53 and after some investigation, I found that the "dhcpcd" client (maybe others, too) don't send the MESSAGE TYPE as the first option (see Wireshark dump attached in the linked issue). This seems to be valid since the order of the options contained in the package shouldn't matter. However, tinyUSB's DHCP server expects the MESSAGE TYPE to be the first option.

This change uses the already existing function to extract the MESSAGE TYPE option from the options properly. It will also fail now, if the MESSAGE TYPE option doesn't exist at all, making the code safer than the current approach.