### PR TITLE
Update on reset of mpu6050_i2c.c

### DIFF
--- a/i2c/mpu6050_i2c/mpu6050_i2c.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.c
@@ -37,7 +37,7 @@ static int addr = 0x68;
 static void mpu6050_reset() {
     // Two byte reset. First byte register, second byte data
     // There are a load more options to set up the device in different ways that could be added here
-    uint8_t buf[] = {0x6B, 0x00};
+    uint8_t buf[] = {0x6B, 0x80};
     i2c_write_blocking(i2c_default, addr, buf, 2, false);
 }
 


### PR DESCRIPTION
To reset the MPU6050, the device_reset bit shall be set to '1'.

reference from "MPU-6000/MPU-6050 Register Map and Descriptions"
DEVICE_RESET : When set to 1, this bit resets all internal registers to their default values. The bit automatically clears to 0 once the reset is done.