### PR TITLE
A2ds source demo add usb control

### DIFF
--- a/pico_w/bt/a2dp_source_demo/CMakeLists.txt
+++ b/pico_w/bt/a2dp_source_demo/CMakeLists.txt
@@ -1,1 +1,5 @@
 picow_bt_example(a2dp_source_demo pico_btstack_hxcmod_player pico_btstack_sbc_encoder)
+
+# enable usb output, disable uart output
+pico_enable_stdio_usb(picow_bt_example_a2dp_source_demo_background 1)
+pico_enable_stdio_uart(picow_bt_example_a2dp_source_demo_background 0)


### PR DESCRIPTION
This PR makes the [a2ds_source_demo](../blob/master/pico_w/bt/a2dp_source_demo) example a bit more accessible by exposing the UI over a USB/Serial connection.

[btstack/examples/a2ds_source_demo](https://github.com/bluekitchen/btstack/blob/master/example/a2dp_source_demo.c) provides a UI for paring with an audio sink, controlling volume, starting and stopping playback etc. This works straightforwardly on desktop since `stdout/stdin` are generally connected, but not on a RPi pico_w. The modifications in this PR expose that same UI over a USB/serial connection (borrowing code from some of the other examples).

When the application is run via an RPi/w connected by USB, you can connect to the UI with e.g. `screen /dev/tty.usbmodem*`, then hitting `space` on MacOS. Next, put any audio sink (e.g. a pair of Bluetooth headphones) in pairing mode, and type `a` in the UI to scan for devices and connect. Once connected the audio from the example should start playing in the sink device, and you can control playback in the UI.

I think these modifications make the example a bit more useful, but I don't know either Bluetooth, Raspberry PI or this project very well so if they're inappropriate my apologies and please close the PR.