### PR TITLE
Improve on github workflow uses of make

### DIFF
--- a/.github/workflows/multi-gcc.yml
+++ b/.github/workflows/multi-gcc.yml
@@ -40,146 +40,142 @@ jobs:
       working-directory: ${{github.workspace}}/pico-examples
       run:  cmake -E make_directory ${{github.workspace}}/pico-examples/build
 
-    - name: Get core count
-      id: core_count
-      run : cat /proc/cpuinfo  | grep processor | wc -l
-
     - name: GCC 6.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6_2-2016q4 -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6_2-2016q4 -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 6.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6_2-2016q4 -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6_2-2016q4 -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 6.3.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6-2017-q2-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6-2017-q2-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 6.3.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6-2017-q2-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-6-2017-q2-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 7.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2017-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2017-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 7.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2017-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2017-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 7.3.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2018-q2-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2018-q2-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 7.3.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2018-q2-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-7-2018-q2-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 8.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2018-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2018-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 8.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2018-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2018-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 8.3.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2019-q3-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2019-q3-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 8.3.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2019-q3-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-8-2019-q3-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 9.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2019-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2019-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 9.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2019-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2019-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 9.3.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2020-q2-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2020-q2-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 9.3.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2020-q2-update -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-9-2020-q2-update -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 10.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10-2020-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10-2020-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 10.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10-2020-q4-major -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10-2020-q4-major -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 10.3.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10.3-2021.10 -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10.3-2021.10 -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 10.3.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10.3-2021.10 -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-none-eabi-10.3-2021.10 -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 11.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 11.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 11.3.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 11.3.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 12.2.1 Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: GCC 12.2.1 Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_TOOLCHAIN_PATH=/opt/arm/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi -DPICO_BOARD=pico_w; make -OrRj$(nproc)
 
     - name: Native Debug
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_PLATFORM=host; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Debug -DPICO_PLATFORM=host; make -OrRj$(nproc)
 
     - name: Native Release
       if: always()
       shell: bash
-      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_PLATFORM=host; make -j ${{steps.core_count.outputs.output}}
+      run: cd ${{github.workspace}}/pico-examples; mkdir -p build; rm -rf build/*; cd build; PICO_SDK_PATH=../../pico-sdk cmake ../ -DCMAKE_BUILD_TYPE=Release -DPICO_PLATFORM=host; make -OrRj$(nproc)


### PR DESCRIPTION
- Fix use of jobs count for throttling parallelism.
  - Would appear the prior variable expanded to nothing. 
  - Option -j should be followed by jobs count without space in between, e.g. -j24.
- Synchronize output per target (-O).
  - Makes reading logs easier when command and output are adjacent.
  - "Deeper" synchronization may be preferable.
- Omit built-in variables (-R) and rules (-r).
  - Saves a few milliseconds starting up make, in my experience.
  - CMake defines all rules and variables from scratch for what I know, superceding any built-ins.