### PR TITLE
Fix PICO_VBUS_PIN

### DIFF
--- a/adc/read_vsys/power_status.c
+++ b/adc/read_vsys/power_status.c
@@ -49,13 +49,11 @@ int power_voltage(float *voltage_result) {
     adc_fifo_setup(true, false, 0, false, false);
     adc_run(true);
 
-#if CYW43_USES_VSYS_PIN
-    // We seem to read low values from cyw43 sometimes - this seems to fix it
+    // We seem to read low values initially - this seems to fix it
     int ignore_count = PICO_POWER_SAMPLE_COUNT;
     while (!adc_fifo_is_empty() || ignore_count-- > 0) {
         (void)adc_fifo_get_blocking();
     }
-#endif
 
     // read vsys
     uint32_t vsys = 0;

--- a/adc/read_vsys/power_status.c
+++ b/adc/read_vsys/power_status.c
@@ -23,9 +23,9 @@ int power_source(bool *battery_powered) {
 #if defined CYW43_WL_GPIO_VBUS_PIN
     *battery_powered = !cyw43_arch_gpio_get(CYW43_WL_GPIO_VBUS_PIN);
     return PICO_OK;
-#elif defined PICO_VBUS_GPIO_PIN
-    gpio_set_function(PICO_VBUS_GPIO_PIN, GPIO_FUNC_SIO);
-    *battery_powered = !gpio_get(PICO_VBUS_GPIO_PIN);
+#elif defined PICO_VBUS_PIN
+    gpio_set_function(PICO_VBUS_PIN, GPIO_FUNC_SIO);
+    *battery_powered = !gpio_get(PICO_VBUS_PIN);
     return PICO_OK;
 #else
     return PICO_ERROR_NO_DATA;


### PR DESCRIPTION
Inexplicably using the wrongly named constant. Should be PICO_VBUS_PIN.
This is used for Pico, Pico W uses CYW43_WL_GPIO_VBUS_PIN