### PR TITLE
ping example app throws lwip assert

### DIFF
--- a/pico_w/wifi/freertos/ping/lwipopts.h
+++ b/pico_w/wifi/freertos/ping/lwipopts.h
@@ -16,6 +16,10 @@
 
 // not necessary, can be done either way
 #define LWIP_TCPIP_CORE_LOCKING_INPUT 1
+
+// ping_thread sets socket receive timeout, so enable this feature
+#define LWIP_SO_RCVTIMEO 1
 #endif
+
 
 #endif


### PR DESCRIPTION
Now LWIP_PLATFORM_ASSERT has been fixed we're seeing an assert for the ping example app.
It sets the SO_RCVTIMEO socket option which is not enabled.

Fixes #308