### PR TITLE
Stop hardcoding access point IP address.

### DIFF
--- a/pico_w/wifi/access_point/CMakeLists.txt
+++ b/pico_w/wifi/access_point/CMakeLists.txt
@@ -15,7 +15,10 @@ target_link_libraries(picow_access_point_background
         pico_cyw43_arch_lwip_threadsafe_background
         pico_stdlib
         )
-
+# You can change the address below to change the address of the access point
+target_set_ip_address(picow_access_point_background PRIVATE
+        CYW43_DEFAULT_IP_AP_ADDRESS 192.168.4.1
+        )
 pico_add_extra_outputs(picow_access_point_background)
 
 add_executable(picow_access_point_poll
@@ -32,5 +35,9 @@ target_include_directories(picow_access_point_poll PRIVATE
 target_link_libraries(picow_access_point_poll
         pico_cyw43_arch_lwip_poll
         pico_stdlib
+        )
+# You can change the address below to change the address of the access point
+target_set_ip_address(picow_access_point_poll PRIVATE
+        CYW43_DEFAULT_IP_AP_ADDRESS 192.168.4.1
         )
 pico_add_extra_outputs(picow_access_point_poll)

--- a/pico_w/wifi/access_point/picow_access_point.c
+++ b/pico_w/wifi/access_point/picow_access_point.c
@@ -320,8 +320,17 @@ int main() {
     cyw43_arch_enable_ap_mode(ap_name, password, CYW43_AUTH_WPA2_AES_PSK);
 
     ip4_addr_t mask;
-    IP4_ADDR(ip_2_ip4(&state->gw), 192, 168, 4, 1);
-    IP4_ADDR(ip_2_ip4(&mask), 255, 255, 255, 0);
+
+    #if LWIP_IPV6
+    #define IP(x) ((x).u_addr.ip4)
+    #else
+    #define IP(x) (x)
+    #endif
+
+    IP(state->gw).addr = PP_HTONL(CYW43_DEFAULT_IP_AP_ADDRESS);
+    IP(mask).addr = PP_HTONL(CYW43_DEFAULT_IP_MASK);
+
+    #undef IP
 
     // Start the dhcp server
     dhcp_server_t dhcp_server;


### PR DESCRIPTION
Use CYW43_DEFAULT_IP_AP_ADDRESS instead.

Fixes #383