### PR TITLE
Adding launch.json for the debug probe

### DIFF
--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -37,6 +37,7 @@ The example assumes:
     * `launch-probe-swd.json` if the target is connected via an SWD probe (e.g. picoprobe)
     * `launch-raspberrypi-swd.json` if the target is directly connected to a Raspberry Pi GPIO 
     * `launch-remote-openocd.json` if VSCode should connect to an already running instance of `OpenOCD`.
+    * `launch-debug-probe.json` if the target is connected to a [Raspberry Pi Debug Probe](https://www.raspberrypi.com/documentation/microcontrollers/debug-probe.html)
 
 > Be sure to review the selected file and make any changes needed for your environment.
 

--- a/ide/vscode/launch-debug-probe.json
+++ b/ide/vscode/launch-debug-probe.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Pico Debug",
+            "cwd": "${workspaceRoot}",
+            "executable": "${command:cmake.launchTargetPath}",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            // This may need to be "arm-none-eabi-gdb" for some previous builds
+            "gdbPath" : "gdb-multiarch",
+            "device": "RP2040",
+            "configFiles": [
+                // This may need to be "interface/picoprobe.cfg" for some previous builds
+                "interface/cmsis-dap.cfg",
+                "target/rp2040.cfg"
+            ],
+            "svdFile": "${env:PICO_SDK_PATH}/src/rp2040/hardware_regs/rp2040.svd",
+            "runToEntryPoint": "main",
+            // Work around for stopping at main on restart
+            "postRestartCommands": [
+                "break main",
+                "continue"
+            ]
+        }
+    ]
+}

--- a/ide/vscode/launch-debug-probe.json
+++ b/ide/vscode/launch-debug-probe.json
@@ -2,7 +2,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Pico Debug",
+            "name": "Pico Debug Probe",
             "cwd": "${workspaceRoot}",
             "executable": "${command:cmake.launchTargetPath}",
             "request": "launch",
@@ -10,6 +10,9 @@
             "servertype": "openocd",
             // This may need to be "arm-none-eabi-gdb" for some previous builds
             "gdbPath" : "gdb-multiarch",
+            "serverArgs": [
+                "-c", "adapter speed 5000"
+            ],
             "device": "RP2040",
             "configFiles": [
                 // This may need to be "interface/picoprobe.cfg" for some previous builds


### PR DESCRIPTION
Currently, none of the candidate launch.json files in the ide/vscode folder work with the (relatively new) official Debug Probe. Although similar to the pico-probe, there are some small differences. It took a considerable time to work out the changes needed to get it to work.
 
The proposal here is to add an additional file (and reference in the readme) with these changes. It is also labelled launch-debug-probe.json to match the product name.
The README is also updated (although I am not sure about including the URL of the product page - is that a stable URL?)