### PR TITLE
update tcp_server to allow for usb CMakeLists.txt

### DIFF
--- a/pico_w/wifi/tcp_server/CMakeLists.txt
+++ b/pico_w/wifi/tcp_server/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(picow_tcpip_server_background
         pico_cyw43_arch_lwip_threadsafe_background
         pico_stdlib
         )
-
+pico_enable_stdio_usb(picow_tcpip_server_background 1)
 pico_add_extra_outputs(picow_tcpip_server_background)
 
 add_executable(picow_tcpip_server_poll
@@ -31,4 +31,5 @@ target_link_libraries(picow_tcpip_server_poll
         pico_cyw43_arch_lwip_poll
         pico_stdlib
         )
+pico_enable_stdio_usb(picow_tcpip_server_poll 1)
 pico_add_extra_outputs(picow_tcpip_server_poll)


### PR DESCRIPTION
without picow_tcpip_server_poll the printf's like this: https://github.com/raspberrypi/pico-examples/blob/eca13acf57916a0bd5961028314006983894fc84/pico_w/wifi/tcp_server/picow_tcp_server.c#L258
do not show anywhere. I burned hours wondering if the code was running.

Should we think about making all of the examples turn on usb stdio by default? Since you have to used the USB to install the app it sure would make it easy to see debug every example was set to show stdio to the usb serial.