### PR TITLE
Update launch-probe-swd.json

### DIFF
--- a/ide/vscode/launch-probe-swd.json
+++ b/ide/vscode/launch-probe-swd.json
@@ -16,6 +16,9 @@
                 "interface/cmsis-dap.cfg",
                 "target/rp2040.cfg"
             ],
+            "openOCDLaunchCommands": [
+                "adapter speed 5000"
+            ],
             "svdFile": "${env:PICO_SDK_PATH}/src/rp2040/hardware_regs/rp2040.svd",
             "runToEntryPoint": "main",
             // Work around for stopping at main on restart


### PR DESCRIPTION
adding openOCD configuration to launch-probe-swd.json that is needed according to the Getting Started doc. Fixes the issue from [this Stack Overflow question](https://stackoverflow.com/questions/75703331/how-to-add-arguments-to-launch-json-in-vs-code).