### PR TITLE
Fix for issue #446: No red LED lights up in apa102.c example program.

### DIFF
--- a/pio/apa102/apa102.c
+++ b/pio/apa102/apa102.c
@@ -62,7 +62,7 @@ int main() {
         for (int i = 0; i < N_LEDS; ++i) {
             put_rgb888(pio, sm,
                        wave_table[(i + t) % TABLE_SIZE],
-                       wave_table[(2 * i + 3 * 2) % TABLE_SIZE],
+                       wave_table[(2 * i + 3 * t) % TABLE_SIZE],
                        wave_table[(3 * i + 4 * t) % TABLE_SIZE]
             );
         }


### PR DESCRIPTION
Simple typo correction which makes the red LED lights turn on as expected, following the wave pattern.