### PR TITLE
Add additional C++ Example for AM2302-Sensor

### DIFF
--- a/gpio/AM2302_sensor/AM2302-Sensor.cpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.cpp
@@ -1,0 +1,191 @@
+/*
+*	AM2302-Sensor.cpp
+*
+*	Author: Frank Häfele
+*	Date:	21.11.2023
+*
+*	Object: Measure Sensor Data of AM2302-Sensor
+*
+*/
+#include "AM2302-Sensor.hpp"
+
+/**
+ * @brief Construct a new am2302::am2302 sensor::am2302 sensor object
+ * 
+ * @param pin Pin for AM2302 sensor
+ */
+AM2302::AM2302_Sensor::AM2302_Sensor(uint8_t pin) : _millis_last_read{0}, _pin{pin}
+{}
+
+/**
+ * @brief begin function setup pin and run sensor check.
+ * 
+ * @return true if sensor check is successful.
+ * @return false if sensor check failed.
+ */
+bool AM2302::AM2302_Sensor::begin() {
+   gpio_init(_pin);
+   // required delay() for a secure sensor check,
+   // if you reset the mcu very fast one after another
+   auto tic{time_us_64()};
+   while ( time_us_64() - tic < READ_FREQUENCY * 1000U ) {
+      sleep_ms(1U);
+   }
+   auto status{read()};
+   _millis_last_read = time_us_64();
+   if (status == AM2302_READ_OK) {
+      return true;
+   }
+   else {
+      return false;
+   }
+}
+
+
+int8_t AM2302::AM2302_Sensor::read() {
+   // check read frequency
+   if ( time_us_64() - _millis_last_read < READ_FREQUENCY * 1000U) {
+      return AM2302_ERROR_READ_FREQ;
+   }
+   _millis_last_read = time_us_64();
+   // *****************************
+   //  === send start sequence ===
+   // ****************************
+   // start from HIGH ==> switch to LOW for min. of 1 ms
+   // Set pin to Output
+   gpio_set_dir(_pin, GPIO_OUT);
+   // set Pin to LOW 
+   gpio_put(_pin, 0);
+   // wait min. 1,0 ms
+   sleep_us(1200U);
+   // Set port to HIGH ==> INPUT_PULLUP with PullUp
+   gpio_put(_pin, 1);
+   gpio_set_dir(_pin, GPIO_IN);
+   // delay_us(30.0); not needed
+
+   // ******************************
+   //  === wait for Acknowledge ===
+   // ******************************
+   // Acknowledge Sequence 80us LOW 80 us HIGH
+   // wait for LOW (80 µs)
+   await_state(0);
+   // wait for HIGH (80 µs)
+   await_state(1);
+
+   // *****************************
+   //  ==== Read Sensor Data ====
+   // *****************************
+   // ==> START of time critical code <==
+   // read 40 bits from sensor into the buffer:
+   // ==> HIGH state is 70 µs
+   // ==> LOW state is 28 µs
+   uint8_t _data[5U] = {0};
+   if (read_sensor_data(_data, 5U) == AM2302_ERROR_TIMEOUT) {
+      return AM2302_ERROR_TIMEOUT;
+   }
+   // ==> END of time critical code <==
+   
+   // check checksum
+   _checksum_ok = (_data[4] == ( (_data[0] + _data[1] + _data[2] + _data[3]) & 0xFF) );
+
+   /*
+   // Code part to check the checksum
+   // Due to older sensors have an bug an deliver wrong data
+   auto d4 = _data[4];
+   auto cs = ( (_data[0] + _data[1] + _data[2] + _data[3]) & 0xFF) ;
+   Serial.print("delivered Checksum:  ");
+   AM2302_Tools::print_byte_as_bit(d4);
+   Serial.print("calculated Checksum: ");
+   AM2302_Tools::print_byte_as_bit(cs);
+   */
+
+   if (_checksum_ok) {
+      _hum  = static_cast<uint16_t>((_data[0] << 8) | _data[1]);
+      if (_data[2] & 0x80) {
+         // negative temperature detected
+         _data[2] &= 0x7f;
+         _temp = -static_cast<int16_t>((_data[2] << 8) | _data[3]);
+      }
+      else {
+         _temp = static_cast<int16_t>((_data[2] << 8) | _data[3]);
+      }
+      return AM2302_READ_OK;
+   }
+   else {
+      return AM2302_ERROR_CHECKSUM;
+   }
+}
+
+/**
+ * @brief wait for a specific pin state
+ * 
+ * @param state state to wait for
+ * @return int8_t status
+ */
+int8_t AM2302::AM2302_Sensor::await_state(uint8_t state) {
+   uint8_t wait_counter{0}, state_counter{0};
+   // count wait for state time
+   while ( (gpio_get(_pin) != state) ) {
+      ++wait_counter;
+      sleep_us(1U);
+      if (wait_counter >= READ_TIMEOUT) {
+         return AM2302_ERROR_TIMEOUT;
+      }
+   }
+   // count state time
+   while ( (gpio_get(_pin) == state) ) {
+      ++state_counter;
+      sleep_us(1U);
+      if (state_counter >= READ_TIMEOUT) {
+         return AM2302_ERROR_TIMEOUT;
+      }
+   }
+   return (state_counter > wait_counter);
+}
+
+/**
+ * @brief read sensor data
+ * 
+ * @param buffer data buffer of 40 bit
+ * @param size of buffer => 40
+ * @return int8_t 
+ */
+int8_t AM2302::AM2302_Sensor::read_sensor_data(uint8_t *buffer, uint8_t size) {
+   for (uint8_t i = 0; i < size; ++i) {
+      for (uint8_t bit = 0; bit < 8U; ++bit) {
+         uint8_t wait_counter{0}, state_counter{0};
+         // count wait for state time
+         while ( !gpio_get(_pin) ) {
+            ++wait_counter;
+            sleep_us(1U);
+            if (wait_counter >= READ_TIMEOUT) {
+               return AM2302_ERROR_TIMEOUT;
+            }
+         }
+         // count state time
+         while ( gpio_get(_pin) ) {
+            ++state_counter;
+            sleep_us(1U);
+            if (state_counter >= READ_TIMEOUT) {
+               return AM2302_ERROR_TIMEOUT;
+            }
+         }
+         buffer[i] <<= 1;
+         buffer[i] |= (state_counter > wait_counter);
+      }
+   }
+   return AM2302_READ_OK;
+}
+
+/**
+ * @brief helper function to print byte as bit
+ * 
+ * @param value byte with 8 bits
+ */
+void AM2302_Tools::print_byte_as_bit(char value) {
+   for (int i = 7; i >= 0; --i) {
+      char c = (value & (1 << i)) ? '1' : '0';
+      printf("%c", c);
+   }
+   printf("\n");
+}

--- a/gpio/AM2302_sensor/AM2302-Sensor.cpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.cpp
@@ -1,12 +1,14 @@
 /*
 *	AM2302-Sensor.cpp
 *
-*	Author: Frank Häfele
-*	Date:	21.11.2023
+*	Author:  Frank Häfele
+*	Date:    25.04.2024
 *
-*	Object: Measure Sensor Data of AM2302-Sensor
+*	Objective: AM2302-Sensor class
 *
+*  SPDX-License-Identifier: BSD-3-Clause
 */
+
 #include "AM2302-Sensor.hpp"
 
 /**

--- a/gpio/AM2302_sensor/AM2302-Sensor.cpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.cpp
@@ -67,7 +67,6 @@ int8_t AM2302::AM2302_Sensor::read() {
       // nothing to do
       return status;
    }
-   return status;
 }
 
 /**
@@ -215,7 +214,7 @@ int8_t AM2302::AM2302_Sensor::read_sensor_data(uint8_t *buffer, uint8_t size) {
  * 
  * @return sensor state
 */
-const char * AM2302::AM2302_Sensor::get_sensorState(int8_t state) const {
+const char * AM2302::AM2302_Sensor::get_sensorState(int8_t state) {
    if(state == AM2302_READ_OK) {
       return AM2302_STATE_OK;
    }

--- a/gpio/AM2302_sensor/AM2302-Sensor.cpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.cpp
@@ -14,7 +14,7 @@
  * 
  * @param pin Pin for AM2302 sensor
  */
-AM2302::AM2302_Sensor::AM2302_Sensor(uint8_t pin) : _millis_last_read{0}, _pin{pin}
+AM2302::AM2302_Sensor::AM2302_Sensor(uint8_t pin) : _us_last_read{0}, _pin{pin}
 {}
 
 /**
@@ -33,7 +33,7 @@ bool AM2302::AM2302_Sensor::begin() {
       sleep_ms(1U);
    }
    auto status{read()};
-   _millis_last_read = time_us_64();
+   _us_last_read = time_us_64();
    if (status == AM2302_READ_OK) {
       return true;
    }
@@ -75,10 +75,10 @@ int8_t AM2302::AM2302_Sensor::read() {
 */
 int8_t AM2302::AM2302_Sensor::read_sensor() {
    // check read frequency
-   if ( time_us_64() - _millis_last_read < READ_FREQUENCY * 1000U) {
+   if ( time_us_64() - _us_last_read < READ_FREQUENCY * 1000U) {
       return AM2302_ERROR_READ_FREQ;
    }
-   _millis_last_read = time_us_64();
+   _us_last_read = time_us_64();
    // *****************************
    //  === send start sequence ===
    // ****************************

--- a/gpio/AM2302_sensor/AM2302-Sensor.cpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.cpp
@@ -14,7 +14,7 @@
  * 
  * @param pin Pin for AM2302 sensor
  */
-AM2302::AM2302_Sensor::AM2302_Sensor(uint8_t pin) : _millis_last_read{0}, _pin{pin}
+AM2302::AM2302_Sensor::AM2302_Sensor(uint8_t pin) : _us_last_read{0}, _pin{pin}
 {}
 
 /**
@@ -32,7 +32,7 @@ bool AM2302::AM2302_Sensor::begin() {
       sleep_ms(1U);
    }
    auto status{read()};
-   _millis_last_read = time_us_64();
+   _us_last_read = time_us_64();
    if (status == AM2302_READ_OK) {
       return true;
    }
@@ -44,10 +44,10 @@ bool AM2302::AM2302_Sensor::begin() {
 
 int8_t AM2302::AM2302_Sensor::read() {
    // check read frequency
-   if ( time_us_64() - _millis_last_read < READ_FREQUENCY * 1000U) {
+   if ( time_us_64() - _us_last_read < READ_FREQUENCY * 1000U) {
       return AM2302_ERROR_READ_FREQ;
    }
-   _millis_last_read = time_us_64();
+   _us_last_read = time_us_64();
    // *****************************
    //  === send start sequence ===
    // ****************************

--- a/gpio/AM2302_sensor/AM2302-Sensor.hpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.hpp
@@ -1,0 +1,53 @@
+/*__AM2302_SENSOR_H__
+*	AM2302-Sensor.h
+*
+*	Author: Frank Häfele
+*	Date:	21.11.2023
+*
+*	Object: Measure Sensor Data of AM2302-Sensor
+*
+*/
+
+#ifndef __AM2302_SENSOR_H__
+#define __AM2302_SENSOR_H__
+#include <cstdint>
+#include <cstdio>
+#include "pico/stdlib.h"
+#include "hardware/gpio.h"
+
+namespace AM2302 {
+
+   constexpr int8_t AM2302_READ_OK          {0};
+   constexpr int8_t AM2302_ERROR_CHECKSUM   {-1};
+   constexpr int8_t AM2302_ERROR_TIMEOUT    {-2};
+   constexpr int8_t AM2302_ERROR_READ_FREQ  {-3};
+
+   // define timeout in 100 µs
+   constexpr uint8_t READ_TIMEOUT         {100U};
+   constexpr uint16_t READ_FREQUENCY      {2000U};
+
+   class AM2302_Sensor {
+
+      public:
+         explicit AM2302_Sensor(uint8_t pin);
+         bool begin();
+         int8_t read();
+         float get_Temperature() const {return _temp * 0.1F;}
+         float get_Humidity() const {return _hum * 0.1F;}
+
+      private:
+         unsigned long _millis_last_read;
+         uint16_t _hum {0};
+         int16_t _temp {0};
+         uint8_t _pin;
+         bool _checksum_ok {false};
+         int8_t await_state(uint8_t state);
+         int8_t read_sensor_data(uint8_t *buffer, uint8_t const size);
+   };
+}
+
+namespace AM2302_Tools {
+    void print_byte_as_bit(char value);
+}
+
+#endif

--- a/gpio/AM2302_sensor/AM2302-Sensor.hpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.hpp
@@ -1,11 +1,12 @@
-/*__AM2302_SENSOR_H__
-*	AM2302-Sensor.h
+/*
+*	AM2302-Sensor.hpp
 *
-*	Author: Frank Häfele
-*	Date:	21.11.2023
+*	Author:  Frank Häfele
+*	Date:    25.04.2024
 *
-*	Object: Measure Sensor Data of AM2302-Sensor
+*	Objective: AM2302-Sensor class
 *
+*  SPDX-License-Identifier: BSD-3-Clause
 */
 
 #ifndef __AM2302_SENSOR_H__

--- a/gpio/AM2302_sensor/AM2302-Sensor.hpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.hpp
@@ -24,6 +24,8 @@ namespace AM2302 {
 
    // define timeout in 100 µs
    constexpr uint8_t READ_TIMEOUT         {100U};
+
+   // define maximum sensor read frequency in milliseconds (2 s)
    constexpr uint16_t READ_FREQUENCY      {2000U};
 
    class AM2302_Sensor {
@@ -36,7 +38,7 @@ namespace AM2302 {
          float get_Humidity() const {return _hum * 0.1F;}
 
       private:
-         unsigned long _millis_last_read;
+         unsigned long _us_last_read;
          uint16_t _hum {0};
          int16_t _temp {0};
          uint8_t _pin;

--- a/gpio/AM2302_sensor/AM2302-Sensor.hpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.hpp
@@ -17,6 +17,11 @@
 
 namespace AM2302 {
 
+   constexpr const char * AM2302_STATE_OK{"OK"};
+   constexpr const char * AM2302_STATE_ERR_CKSUM{"Error: Checksum"};
+   constexpr const char * AM2302_STATE_ERR_TIMEOUT{"Error: Timeout"};
+   constexpr const char * AM2302_STATE_ERR_READ_FREQ{"Error: Read Frequency"};
+
    constexpr int8_t AM2302_READ_OK          {0};
    constexpr int8_t AM2302_ERROR_CHECKSUM   {-1};
    constexpr int8_t AM2302_ERROR_TIMEOUT    {-2};
@@ -24,8 +29,6 @@ namespace AM2302 {
 
    // define timeout in 100 µs
    constexpr uint8_t READ_TIMEOUT         {100U};
-
-   // define maximum sensor read frequency in milliseconds (2 s)
    constexpr uint16_t READ_FREQUENCY      {2000U};
 
    class AM2302_Sensor {
@@ -36,15 +39,18 @@ namespace AM2302 {
          int8_t read();
          float get_Temperature() const {return _temp * 0.1F;}
          float get_Humidity() const {return _hum * 0.1F;}
+         const char * get_sensorState(int8_t state) const;
 
       private:
-         unsigned long _us_last_read;
+         unsigned long _millis_last_read;
          uint16_t _hum {0};
          int16_t _temp {0};
          uint8_t _pin;
          bool _checksum_ok {false};
          int8_t await_state(uint8_t state);
+         int8_t read_sensor();
          int8_t read_sensor_data(uint8_t *buffer, uint8_t const size);
+         void resetData();
    };
 }
 

--- a/gpio/AM2302_sensor/AM2302-Sensor.hpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.hpp
@@ -41,7 +41,7 @@ namespace AM2302 {
          int8_t read();
          float get_Temperature() const {return _temp * 0.1F;}
          float get_Humidity() const {return _hum * 0.1F;}
-         const char * get_sensorState(int8_t state) const;
+         static const char * get_sensorState(int8_t state);
 
       private:
          unsigned long _us_last_read;

--- a/gpio/AM2302_sensor/AM2302-Sensor.hpp
+++ b/gpio/AM2302_sensor/AM2302-Sensor.hpp
@@ -29,6 +29,7 @@ namespace AM2302 {
 
    // define timeout in 100 µs
    constexpr uint8_t READ_TIMEOUT         {100U};
+   // read cycle max every 2 s
    constexpr uint16_t READ_FREQUENCY      {2000U};
 
    class AM2302_Sensor {
@@ -42,7 +43,7 @@ namespace AM2302 {
          const char * get_sensorState(int8_t state) const;
 
       private:
-         unsigned long _millis_last_read;
+         unsigned long _us_last_read;
          uint16_t _hum {0};
          int16_t _temp {0};
          uint8_t _pin;

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -8,7 +8,7 @@
 #include "pico/stdlib.h"
 #include "AM2302-Sensor.hpp"
 
-const uint LED_PIN = 13U;
+const uint LED_PIN = PICO_DEFAULT_LED_PIN;
 
 // DHT Pin
 const uint DHT_PIN = 15;

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <cstdio>
+#include "pico/stdlib.h"
+#include "AM2302-Sensor.hpp"
+
+const uint LED = 13U;
+
+// DHT Pin
+const uint DHT_PIN = 15;
+
+// create am2302 object
+AM2302::AM2302_Sensor am2302{DHT_PIN};
+
+int main() {
+    stdio_init_all();
+
+#ifdef LED_PIN
+    gpio_init(LED_PIN);
+    gpio_set_dir(LED_PIN, GPIO_OUT);
+#endif
+    
+    printf("\n\n === Pi Pico C++ Example - Read AM2302-Sensor === \n\n");
+    // setup pin and do a sensor check
+    if (!am2302.begin()) {
+        while(true) {
+           printf("ERROR: during sensor check! Pleae check sensor connectivity!\n");
+           sleep_ms(10000);
+        }
+    }
+    sleep_ms(3000);
+    while (true) {
+
+#ifdef LED_PIN
+        gpio_put(LED_PIN, 1);
+#endif
+        int8_t status = am2302.read();
+
+#ifdef LED_PIN
+    gpio_put(LED_PIN, 0);
+#endif
+
+        printf("Sensor-status: %d\n", status);
+
+        if (status == AM2302::AM2302_READ_OK) {
+            printf("Humidity = %.1f %%\tTemperature = %.1f degC\n",
+                am2302.get_Humidity(), am2302.get_Temperature());
+        }
+        else {
+            if (status == AM2302::AM2302_ERROR_CHECKSUM) {
+                printf("ERROR: Checksum not valid\n");
+            }
+            else if (status == AM2302::AM2302_ERROR_TIMEOUT) {
+                printf("ERROR: Timeout overflow\n");
+            }
+            else if (status == AM2302::AM2302_ERROR_READ_FREQ) {
+                printf("ERROR: Read frequency too high!\n");
+            }
+        }
+        printf("\n\n");
+        sleep_ms(2000);
+    }
+}

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -1,11 +1,12 @@
 /**
+ * AM2302.cpp
+ * 
  * Author:  Frank Häfele
- *
  * Date:    25.04.2024
  * 
- * SPDX-License-Identifier: BSD-3-Clause
- * 
  * Objective: Read one or multiple AM2302-Sensors
+ * 
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <cstdio>

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -8,7 +8,7 @@
 #include "pico/stdlib.h"
 #include "AM2302-Sensor.hpp"
 
-const uint LED = 13U;
+const uint LED_PIN = 13U;
 
 // DHT Pin
 const uint DHT_PIN = 15;
@@ -19,10 +19,8 @@ AM2302::AM2302_Sensor am2302{DHT_PIN};
 int main() {
     stdio_init_all();
 
-#ifdef LED_PIN
     gpio_init(LED_PIN);
     gpio_set_dir(LED_PIN, GPIO_OUT);
-#endif
     
     printf("\n\n === Pi Pico C++ Example - Read AM2302-Sensor === \n\n");
     // setup pin and do a sensor check
@@ -35,14 +33,10 @@ int main() {
     sleep_ms(3000);
     while (true) {
 
-#ifdef LED_PIN
         gpio_put(LED_PIN, 1);
-#endif
         int8_t status = am2302.read();
 
-#ifdef LED_PIN
     gpio_put(LED_PIN, 0);
-#endif
 
         printf("Sensor-status: %d\n", status);
 

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -45,7 +45,7 @@ int main() {
         gpio_put(LED_PIN, 1);
         printf("\n\tStatus        :");
         for (size_t i = 0; i < SIZE; ++i) {
-            printf("\t%s", am2302[i].get_sensorState(am2302[i].read()));
+            printf("\t%s", AM2302::AM2302_Sensor::get_sensorState(am2302[i].read()));
         }
         printf("\n\tTemperature   :");
         gpio_put(LED_PIN, 0);

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -3,6 +3,8 @@
  *
  * Date:    25.04.2024
  * 
+ * SPDX-License-Identifier: BSD-3-Clause
+ * 
  * Objective: Read one or multiple AM2302-Sensors
  */
 

--- a/gpio/AM2302_sensor/AM2302.cpp
+++ b/gpio/AM2302_sensor/AM2302.cpp
@@ -1,7 +1,9 @@
 /**
- * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Author:  Frank Häfele
  *
- * SPDX-License-Identifier: BSD-3-Clause
+ * Date:    25.04.2024
+ * 
+ * Objective: Read one or multiple AM2302-Sensors
  */
 
 #include <cstdio>
@@ -11,10 +13,15 @@
 const uint LED_PIN = PICO_DEFAULT_LED_PIN;
 
 // DHT Pin
-const uint DHT_PIN = 15;
+const uint8_t SIZE = 3U;
+const uint8_t PINS[SIZE] = {13U, 14U, 15U};
 
 // create am2302 object
-AM2302::AM2302_Sensor am2302{DHT_PIN};
+AM2302::AM2302_Sensor am2302[SIZE] = {
+    AM2302::AM2302_Sensor{PINS[0]},
+    AM2302::AM2302_Sensor{PINS[1]},
+    AM2302::AM2302_Sensor{PINS[2]}
+};
 
 int main() {
     stdio_init_all();
@@ -24,38 +31,30 @@ int main() {
     
     printf("\n\n === Pi Pico C++ Example - Read AM2302-Sensor === \n\n");
     // setup pin and do a sensor check
-    if (!am2302.begin()) {
-        while(true) {
-           printf("ERROR: during sensor check! Pleae check sensor connectivity!\n");
-           sleep_ms(10000);
-        }
+    
+    for (size_t i = 0; i < SIZE; ++i) {
+        printf("Sensor available : %d\n", am2302[i].begin());
     }
+    printf("\n");
     sleep_ms(3000);
     while (true) {
 
         gpio_put(LED_PIN, 1);
-        int8_t status = am2302.read();
-
-    gpio_put(LED_PIN, 0);
-
-        printf("Sensor-status: %d\n", status);
-
-        if (status == AM2302::AM2302_READ_OK) {
-            printf("Humidity = %.1f %%\tTemperature = %.1f degC\n",
-                am2302.get_Humidity(), am2302.get_Temperature());
+        printf("\n\tStatus        :");
+        for (size_t i = 0; i < SIZE; ++i) {
+            printf("\t%s", am2302[i].get_sensorState(am2302[i].read()));
         }
-        else {
-            if (status == AM2302::AM2302_ERROR_CHECKSUM) {
-                printf("ERROR: Checksum not valid\n");
-            }
-            else if (status == AM2302::AM2302_ERROR_TIMEOUT) {
-                printf("ERROR: Timeout overflow\n");
-            }
-            else if (status == AM2302::AM2302_ERROR_READ_FREQ) {
-                printf("ERROR: Read frequency too high!\n");
-            }
+        printf("\n\tTemperature   :");
+        gpio_put(LED_PIN, 0);
+
+        for (size_t i = 0; i < SIZE; ++i) {
+            printf("\t%5.2f", am2302[i].get_Temperature());
+        }
+        printf("\n\tHumidity      :");
+        for (size_t i = 0; i < SIZE; ++i) {
+            printf("\t%5.2f", am2302[i].get_Humidity());
         }
         printf("\n\n");
-        sleep_ms(2000);
+        sleep_ms(10000);
     }
 }

--- a/gpio/AM2302_sensor/CMakeLists.txt
+++ b/gpio/AM2302_sensor/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(AM2302 AM2302.cpp AM2302-Sensor.cpp)
+
+target_link_libraries(AM2302 pico_stdlib)
+
+pico_add_extra_outputs(AM2302)
+
+# add url via pico_set_program_url
+example_auto_set_url(AM2302)

--- a/gpio/CMakeLists.txt
+++ b/gpio/CMakeLists.txt
@@ -1,4 +1,5 @@
 if (NOT PICO_NO_HARDWARE)
+    add_subdirectory(AM2302_sensor)
     add_subdirectory(dht_sensor)
     add_subdirectory(hello_7segment)
     add_subdirectory(hello_gpio_irq)


### PR DESCRIPTION
# Add a C++ Example for AM2302-Sensor.

- usage of class instantiation
- based on [AM2302-Sensor Lib](https://github.com/hasenradball/AM2302-Sensor)