### PR TITLE
WS2812: Support more than 7 pins in parallel mode

### DIFF
--- a/pio/ws2812/ws2812.pio
+++ b/pio/ws2812/ws2812.pio
@@ -72,7 +72,6 @@ static inline void ws2812_parallel_program_init(PIO pio, uint sm, uint offset, u
     pio_sm_config c = ws2812_parallel_program_get_default_config(offset);
     sm_config_set_out_shift(&c, true, true, 32);
     sm_config_set_out_pins(&c, pin_base, pin_count);
-    sm_config_set_set_pins(&c, pin_base, pin_count);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
 
     int cycles_per_bit = ws2812_parallel_T1 + ws2812_parallel_T2 + ws2812_parallel_T3;


### PR DESCRIPTION
```ws2812_parallel_program_init()``` contained an unneeded call to ```sm_config_set_set_pins()```. When this is called with the ```pin_count``` parameter set to a value larger than 7, the set pin count value in the pinctrl register overflows into the side-set pin count. This can result in hard to diagnose issues where low numbered GPIO pins don't work as expected.

There is an existing ```valid_params_if()``` check in ```sm_config_set_set_pins()``` which would catch this error but it is ignored in Release builds.

This PR just removes this ```sm_config_set_set_pins()``` call as **SET** commands aren't even used by the associated PIO code.

Discovered when trying to explain symptoms noted in [this forum thread](https://forums.raspberrypi.com/viewtopic.php?t=362071)