### PR TITLE
Add extern "C" to isr_usbctrl in dev_lowlevel

### DIFF
--- a/usb/device/dev_lowlevel/dev_lowlevel.c
+++ b/usb/device/dev_lowlevel/dev_lowlevel.c
@@ -489,6 +489,9 @@ static void usb_handle_buff_status() {
  *
  */
 /// \tag::isr_setup_packet[]
+#ifdef __cplusplus
+extern "C" {
+#endif
 void isr_usbctrl(void) {
     // USB interrupt handler
     uint32_t status = usb_hw->ints;
@@ -520,6 +523,9 @@ void isr_usbctrl(void) {
         panic("Unhandled IRQ 0x%x\n", (uint) (status ^ handled));
     }
 }
+#ifdef __cplusplus
+}
+#endif
 
 /**
  * @brief EP0 in transfer complete. Either finish the SET_ADDRESS process, or receive a zero

--- a/usb/device/dev_lowlevel/dev_lowlevel.c
+++ b/usb/device/dev_lowlevel/dev_lowlevel.c
@@ -488,10 +488,10 @@ static void usb_handle_buff_status() {
  * @brief USB interrupt handler
  *
  */
-/// \tag::isr_setup_packet[]
 #ifdef __cplusplus
 extern "C" {
 #endif
+/// \tag::isr_setup_packet[]
 void isr_usbctrl(void) {
     // USB interrupt handler
     uint32_t status = usb_hw->ints;


### PR DESCRIPTION
The USB dev_lowlevel example silently fails in C++ because `isr_usbctrl` is name-mangled and therefore not registered as an interrupt handler. This PR adds `extern "C"` to use C linkage for this function and allow compiling as C++.  

It is certainly not the prettiest, but it is necessary for correct behavior (with C++ linkage, none of the host's packets are responded to and the device is useless). The alternative to this is to manually specify `irq_set_exclusive_handler`, probably within `usb_device_init`. The pico-sdk advertises itself as C/C++, so C++ compatibility should be taken into consideration in its examples.