### PR TITLE
lis3dh_i2c: fix TEMP_CFG_REG address

### DIFF
--- a/i2c/lis3dh_i2c/lis3dh_i2c.c
+++ b/i2c/lis3dh_i2c/lis3dh_i2c.c
@@ -27,7 +27,7 @@
 const int ADDRESS = 0x18;
 const uint8_t CTRL_REG_1 = 0x20;
 const uint8_t CTRL_REG_4 = 0x23;
-const uint8_t TEMP_CFG_REG = 0xC0;
+const uint8_t TEMP_CFG_REG = 0x1F;
 
 #ifdef i2c_default
 


### PR DESCRIPTION
TEMP_CFG_REG is 0x1F, not 0xC0. I suspect this is just a typo since the value written to it is 0xC0.

See https://www.mouser.com/datasheet/2/389/lis3dh-1849589.pdf#[{%22num%22%3A141%2C%22gen%22%3A0}%2C{%22name%22%3A%22XYZ%22}%2C61%2C439%2Cnull] .