### PR TITLE
Update hello_watchdog to detect reboot only by watchdog

### DIFF
--- a/watchdog/hello_watchdog/hello_watchdog.c
+++ b/watchdog/hello_watchdog/hello_watchdog.c
@@ -11,7 +11,7 @@
 int main() {
     stdio_init_all();
 
-    if (watchdog_caused_reboot()) {
+    if (watchdog_enable_caused_reboot()) {
         printf("Rebooted by Watchdog!\n");
         return 0;
     } else {


### PR DESCRIPTION
Hello, 

I have changed the `hello_watchdog.c` example to detect only reboot caused by watchdog.

I have used the original example program and there was a wrong detection of watchdog caused reboot. For example, when a program was load on the RP2040 through uf2 file, then the RP2040 restart and the `result of watchdog_caused_reboot()` is `true`.

I have changed it to `watchdog_enable_caused_reboot()` cause based on the documentation found [here](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#ga455aa48ca6f11298e184d2ae0e81a085).

 I have tested it on my own project, the detection was fine without detection of reboot caused by program upload, that is why i do a pull request to help others to use watchdog.