### PR TITLE
fix dht.c error: can read data from DHT 11

### DIFF
--- a/gpio/dht_sensor/dht.c
+++ b/gpio/dht_sensor/dht.c
@@ -48,8 +48,12 @@ void read_from_dht(dht_reading *result) {
 
     gpio_set_dir(DHT_PIN, GPIO_OUT);
     gpio_put(DHT_PIN, 0);
-    sleep_ms(20);
+    sleep_ms(18);
+    gpio_put(DHT_PIN,1);
+    sleep_us(40);
+    
     gpio_set_dir(DHT_PIN, GPIO_IN);
+    
 
 #ifdef LED_PIN
     gpio_put(LED_PIN, 1);
@@ -66,7 +70,7 @@ void read_from_dht(dht_reading *result) {
 
         if ((i >= 4) && (i % 2 == 0)) {
             data[j / 8] <<= 1;
-            if (count > 16) data[j / 8] |= 1;
+            if (count > 35) data[j / 8] |= 1;
             j++;
         }
     }


### PR DESCRIPTION
Hello,
I notice when I use the example `gpio/dht_sensor` in right way, Pico can't read data from DHT11. It toke a night and after reading datasheet [https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf](https://www.mouser.com/datasheet/2/758/DHT11-Technical-Data-Sheet-Translated-Version-1143054.pdf), I find this error according 2 errors:
1. In Line 49~53, it doesn't set high signal in some time.
2. In Line 73, the range of `count` (accumulated time) is 26～28, so need a number larger than 28, I choose 35 for redundancy.
 
This is first time I find this error [[Why DHT11 not work after some times using C in pico - Raspberry Pi Forums](https://forums.raspberrypi.com/viewtopic.php?t=355462#p2130252)](https://forums.raspberrypi.com/viewtopic.php?t=355462l), in this post, I use USB and minicom on Mac.

Recently, I buy a Raspberry Pi 4B to re-test this error following the document [Raspberry Pi Pico C/C++ SDK](https://datasheets.raspberrypi.com/pico/raspberry-pi-pico-c-sdk.pdf) by UART, this error still exists. It displays:

<img width="697" alt="截屏2024-03-28 23 07 16" src="https://github.com/raspberrypi/pico-examples/assets/78771985/b8ceee22-aabb-48e5-bd90-2b68b47bc16e">

The print's dislocation may be according to I ssh to raspberry pi. But the data from DHT11  also are `0`, and print `Bad data`.

After fixing, it displays:
<img width="326" alt="截屏2024-03-28 23 30 45" src="https://github.com/raspberrypi/pico-examples/assets/78771985/aea350b8-78bb-4345-95f3-08c483dbcaa4">

It works well.
