### PR TITLE
WS2812 example: Improve bandwidth tolerance

### DIFF
--- a/pio/ws2812/ws2812.pio
+++ b/pio/ws2812/ws2812.pio
@@ -7,9 +7,13 @@
 .program ws2812
 .side_set 1
 
-.define public T1 2
-.define public T2 5
-.define public T3 3
+; The following constants are selected for broad compatibility with WS2812,
+; WS2812B, and SK6812 LEDs. Other constants may support higher bandwidths for
+; specific LEDs, such as (7,10,8) for WS2812B LEDs.
+
+.define public T1 3
+.define public T2 3
+.define public T3 4
 
 .lang_opt python sideset_init = pico.PIO.OUT_HIGH
 .lang_opt python out_init     = pico.PIO.OUT_HIGH
@@ -49,9 +53,9 @@ static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, 
 
 .program ws2812_parallel
 
-.define public T1 2
-.define public T2 5
-.define public T3 3
+.define public T1 3
+.define public T2 3
+.define public T3 4
 
 .wrap_target
     out x, 32


### PR DESCRIPTION
The WS2812 PIO example uses poor choices of T1, T2, and T3, leading to poor support for transmission frequencies other than 0.8 MHz. Specifically, the example PIO program, when run at a bit frequency of 0.8 MHz, is at the bounds of the tolerances specified in the [WS2812B datasheet](https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf).
This PR improves the maximum bit frequency to 1.028 MHz while remaining within tolerance (a 28% improvement).

### Context:
The WS2812B datasheet lists the following tolerances:
- T0H = `0.4 us +- 0.15 us` = `0.25 us .. 0.55 us`
- T1H = `0.8 us +- 0.15 us` = `0.65 us .. 0.95 us`
- T0L = `0.85 us +- 0.15 us` = `0.7 us .. 1 us`
- T1L = `0.45 us +- 0.15 us` = `0.3 us .. 0.6 us`
Note: This gives a minimum possible time-per-bit of 0.95 us, and a maximum possible time-per-bit of 1.55 us

These relate to the example's constants `T1, T2, T3` as follows:
- T0H = `T1 / (T1 + T2 + T3) / bit_frequency`
- T1H = `(T1 + T2) / (T1 + T2 + T3) / bit_frequency`
- T0L = `T2 / (T1 + T2 + T3) / bit_frequency`
- T1L = `(T2 + T3) / (T1 + T2 + T3) / bit_frequency`

### Analysis of various choices of `T1,T2,T3`:
Here, I use `T_bit` to indicate the time required to transmit 1 bit, `F_bit = 1 / T_bit` as the maximum bit transmission frequency, and `(T1,T2,T3)` as a tuple of constants. In each case, I report the bounds on `T_bit` and `F_bit` required to stay within the tolerance intervals specified in the datasheet.
1. Original example constants:
     - `1.25 us <= T_bit <= 1.25 us`
     - `800,000 Hz <= F_bit <= 800,000 Hz`
     - `(T1,T2,T3) = (2,5,3)` (total 10 PIO cycles / bit)
2. Achieves theoretical maximum bandwidth:
     - `0.95 us <= T_bit <= 1.357 us`
     - `736,843 <= F_bit <= 1,052,631 Hz`
     - `(T1,T2,T3) = (5,8,6)` (total 19 PIO cycles / bit)
3.  High bandwidth with a nice clockdiv value when operating at 1 MHz bandwidth:
     - `0.97223 us <= T_bit <= 1.3888 us`
     - `720,000 Hz <= F_bit <= 1,028,571 Hz`
     - `(T1,T2,T3) = (7,10,8)` (total 25 PIO cycles / bit)
4.  Improved constants without increasing PIO cycles:
     - `1 us <= T_bit <= 1.357 us`
     - `736,843 Hz <= F_bit <= 1,000,000 Hz`
     - `(T1,T2,T3) = (3,4,3)` (total 10 PIO cycles / bit)
5. Achieves theoretical minimum bandwidth:
     - `1.085 us <= T_bit <= 1.55 us`
     - `645,162 Hz <= F_bit <= 921,658 Hz`
     - `(T1,T2,T3) = (11,8,12)` (total 31 PIO cycles / bit)

### Conclusion:
This PR implements timing 3., giving bandwidth options in the range `720000 Hz .. 1028571 Hz`, and has been tested on a 12-LED WS2812B strip at 1 MHz. By making this adjustment, those using the WS2812 example as a starting point will have significantly greater freedom to experiment with alternate bandwidths, without replicating the work above.


### Disclaimer:
Though I am currently employed by IBM, this PR is completely unrelated to my employment, and was undertaken without using either company time or resources.