### PR TITLE
Enhance flash SSI DMA example with interrupt control for stable operations

### DIFF
--- a/flash/ssi_dma/CMakeLists.txt
+++ b/flash/ssi_dma/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(flash_ssi_dma
 target_link_libraries(flash_ssi_dma
         pico_stdlib
         hardware_dma
+        hardware_sync
         )
 
 # create map/bin/hex file etc.

--- a/flash/ssi_dma/CMakeLists.txt
+++ b/flash/ssi_dma/CMakeLists.txt
@@ -13,3 +13,6 @@ pico_add_extra_outputs(flash_ssi_dma)
 
 # add url via pico_set_program_url
 example_auto_set_url(flash_ssi_dma)
+
+pico_enable_stdio_usb(flash_ssi_dma 1)
+pico_enable_stdio_uart(flash_ssi_dma 0)

--- a/flash/ssi_dma/CMakeLists.txt
+++ b/flash/ssi_dma/CMakeLists.txt
@@ -13,6 +13,3 @@ pico_add_extra_outputs(flash_ssi_dma)
 
 # add url via pico_set_program_url
 example_auto_set_url(flash_ssi_dma)
-
-pico_enable_stdio_usb(flash_ssi_dma 1)
-pico_enable_stdio_uart(flash_ssi_dma 0)

--- a/flash/ssi_dma/flash_ssi_dma.c
+++ b/flash/ssi_dma/flash_ssi_dma.c
@@ -11,6 +11,7 @@
 #include "pico/time.h"
 #include "hardware/dma.h"
 #include "hardware/structs/ssi.h"
+#include "hardware/sync.h"
 
 // This example DMAs 16kB of data from the start of flash to SRAM, and
 // measures the transfer speed.
@@ -70,7 +71,11 @@ int main() {
 
     printf("Starting DMA\n");
     uint32_t start_time = time_us_32();
+
+    uint32_t ints = save_and_disable_interrupts();
     flash_bulk_read(rxdata, 0, DATA_SIZE_WORDS, 0);
+    restore_interrupts(ints);
+
     uint32_t finish_time = time_us_32();
     printf("DMA finished\n");
 

--- a/flash/ssi_dma/flash_ssi_dma.c
+++ b/flash/ssi_dma/flash_ssi_dma.c
@@ -67,6 +67,8 @@ uint32_t *expect = (uint32_t *) XIP_NOCACHE_NOALLOC_BASE;
 
 int main() {
     stdio_init_all();
+    
+    sleep_ms(2500);
     memset(rxdata, 0, DATA_SIZE_WORDS * sizeof(uint32_t));
 
     printf("Starting DMA\n");

--- a/flash/ssi_dma/flash_ssi_dma.c
+++ b/flash/ssi_dma/flash_ssi_dma.c
@@ -68,7 +68,6 @@ uint32_t *expect = (uint32_t *) XIP_NOCACHE_NOALLOC_BASE;
 int main() {
     stdio_init_all();
     
-    sleep_ms(2500);
     memset(rxdata, 0, DATA_SIZE_WORDS * sizeof(uint32_t));
 
     printf("Starting DMA\n");


### PR DESCRIPTION
**Description:**

This PR introduces interrupt handling in the flash_ssi_dma example to enhance the stability of flash operations on the Raspberry Pi Pico. 

Based on insights from Kevin Boone's article (https://kevinboone.me/picoflash.html) and flash.h notes on stable flash memory usage, the updated code now disables interrupts during flash operations. Preventing conflicts especially with USB operations that could otherwise cause the program to hang. 

**Changes made:**

Added save_and_disable_interrupts() and restore_interrupts() around the flash operation block to prevent execution interruptions during flash memory access.

