### PR TITLE
fix mpu6050 sensor initialization issue

### DIFF
--- a/i2c/mpu6050_i2c/mpu6050_i2c.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.c
@@ -37,7 +37,7 @@ static int addr = 0x68;
 static void mpu6050_reset() {
     // Two byte reset. First byte register, second byte data
     // There are a load more options to set up the device in different ways that could be added here
-    uint8_t buf[] = {0x6B, 0x80};
+    uint8_t buf[] = {0x6B};
     i2c_write_blocking(i2c_default, addr, buf, 2, false);
 }
 


### PR DESCRIPTION
In my case the sensor (mpu6050), was not initialized correctly and returns erroneous data. 
The proposed changes works fine.
In particular, I'm not sure why the second byte (0x80 == 1000 0000) is messing up the initialization.
As I understand from the documentation (page 40):
https://pdf1.alldatasheet.com/datasheet-pdf/view/1132807/TDK/MPU-6050.html
the seventh bit of register 0x6b should be set to one:
0x80 = 1000 0000
but it doesn't work that way.
