### PR TITLE
MPU6050 i2c example expanded into library

### DIFF
--- a/i2c/mpu6050_i2c/CMakeLists.txt
+++ b/i2c/mpu6050_i2c/CMakeLists.txt
@@ -1,12 +1,21 @@
-add_executable(mpu6050_i2c
-        mpu6050_i2c.c
-        )
-
+add_library(MPU6050_i2c_pico_lib mpu6050_i2c.c)
+target_include_directories(MPU6050_i2c_pico_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 # pull in common dependencies and additional i2c hardware support
-target_link_libraries(mpu6050_i2c pico_stdlib hardware_i2c)
+target_link_libraries(MPU6050_i2c_pico_lib pico_stdlib hardware_i2c)
+
+add_library(MPU6050_i2c_pico_cpp_lib mpu6050.cpp mpu6050_i2c.c)
+target_include_directories(MPU6050_i2c_pico_cpp_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(MPU6050_i2c_pico_cpp_lib pico_stdlib hardware_i2c)
+
+
+add_executable(mpu6050_i2c mpu6050_i2c_main.c)
+target_link_libraries(mpu6050_i2c MPU6050_i2c_pico_lib)
 
 # create map/bin/hex file etc.
 pico_add_extra_outputs(mpu6050_i2c)
+# enable usb output, disable uart output
+pico_enable_stdio_usb(mpu6050_i2c 1)
+pico_enable_stdio_uart(mpu6050_i2c 0)
 
 # add url via pico_set_program_url
 example_auto_set_url(mpu6050_i2c)

--- a/i2c/mpu6050_i2c/mpu6050.cpp
+++ b/i2c/mpu6050_i2c/mpu6050.cpp
@@ -1,0 +1,51 @@
+#include "mpu6050.hpp"
+#include "mpu6050_i2c.h"
+#include "pico/stdlib.h"
+#include "pico/binary_info.h"
+#include "hardware/i2c.h"
+
+static MPU6050_Scale MPU6050::accel_scale;
+static MPU6050_Scale MPU6050::gyro_scale;
+
+/*MPU6050::MPU6050() :  //TODO: is there a good way to do this
+chip_temp(*temp) {
+    accel = {0., 0., 0.};
+    gyro = {0., 0., 0.};
+    temp = {};
+    MPU6050(accel, gyro, temp);
+} */
+
+MPU6050::MPU6050(float *accel_out, float *gyro_out) :
+ accel(accel_out),  gyro(gyro_out), chip_temp(temp) {
+    accel_scale = MPU_FS_0;
+    gyro_scale = MPU_FS_0;
+    //I2C init
+    i2c_init(i2c_default, 400 * 1000); // Max bus speed 400 kHz
+    gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
+    gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
+    gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN);
+    gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
+}
+
+MPU6050::power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle) {
+    mpu6050_power(CLKSEL, temp_disable, sleep, cycle);
+}
+
+MPU6050::reset(void) {
+    mpu6050_reset();
+}
+
+MPU6050::setscale_accel(uint8_t scale_num) {
+    accel_scale = (MPU6050_Scale)(scale_num & 3);
+    mpu6050_setscale_accel(accel_scale);
+}
+
+MPU6050::setscale_gyro(uint8_t scale_num) {
+    gyro_scale = (MPU6050_Scale)(scale_num & 3);
+    mpu6050_setscale_gyro(gyro_scale);
+}
+
+MPU6050::read(void) {
+    mpu6050_read(accel, gyro, &temp, accel_scale, gyro_scale);
+}
+    

--- a/i2c/mpu6050_i2c/mpu6050.cpp
+++ b/i2c/mpu6050_i2c/mpu6050.cpp
@@ -3,7 +3,7 @@
 #include "hardware/i2c.h"
 #include "mpu6050_i2c.h"
 
-/*MPU6050::MPU6050() :  //TODO: is there a good way to do this
+/*MPU6050::MPU6050() :  //TODO: smart pointers
 chip_temp(*temp) {
     accel = {0., 0., 0.};
     gyro = {0., 0., 0.};
@@ -15,12 +15,7 @@ MPU6050::MPU6050(float *accel_out, float *gyro_out) :
  accel(accel_out),  gyro(gyro_out), chip_temp(temp) {
     accel_scale = 0;
     gyro_scale = 0;
-    //I2C init
-    i2c_init(i2c_default, 400 * 1000); // Max bus speed 400 kHz
-    gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
-    gpio_set_function(PICO_DEFAULT_I2C_SCL_PIN, GPIO_FUNC_I2C);
-    gpio_pull_up(PICO_DEFAULT_I2C_SDA_PIN);
-    gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
+    setup_MPU6050_i2c();
 }
 
 void MPU6050::power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle) {

--- a/i2c/mpu6050_i2c/mpu6050.cpp
+++ b/i2c/mpu6050_i2c/mpu6050.cpp
@@ -1,11 +1,7 @@
 #include "mpu6050.hpp"
-#include "mpu6050_i2c.h"
-#include "pico/stdlib.h"
 #include "pico/binary_info.h"
 #include "hardware/i2c.h"
-
-static MPU6050_Scale MPU6050::accel_scale;
-static MPU6050_Scale MPU6050::gyro_scale;
+#include "mpu6050_i2c.h"
 
 /*MPU6050::MPU6050() :  //TODO: is there a good way to do this
 chip_temp(*temp) {
@@ -17,8 +13,8 @@ chip_temp(*temp) {
 
 MPU6050::MPU6050(float *accel_out, float *gyro_out) :
  accel(accel_out),  gyro(gyro_out), chip_temp(temp) {
-    accel_scale = MPU_FS_0;
-    gyro_scale = MPU_FS_0;
+    accel_scale = 0;
+    gyro_scale = 0;
     //I2C init
     i2c_init(i2c_default, 400 * 1000); // Max bus speed 400 kHz
     gpio_set_function(PICO_DEFAULT_I2C_SDA_PIN, GPIO_FUNC_I2C);
@@ -27,25 +23,25 @@ MPU6050::MPU6050(float *accel_out, float *gyro_out) :
     gpio_pull_up(PICO_DEFAULT_I2C_SCL_PIN);
 }
 
-MPU6050::power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle) {
+void MPU6050::power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle) {
     mpu6050_power(CLKSEL, temp_disable, sleep, cycle);
 }
 
-MPU6050::reset(void) {
+void MPU6050::reset(void) {
     mpu6050_reset();
 }
 
-MPU6050::setscale_accel(uint8_t scale_num) {
-    accel_scale = (MPU6050_Scale)(scale_num & 3);
-    mpu6050_setscale_accel(accel_scale);
+void MPU6050::setscale_accel(uint8_t scale_num) {
+    accel_scale = scale_num & 3;
+    mpu6050_setscale_accel((MPU6050_Scale)accel_scale);
 }
 
-MPU6050::setscale_gyro(uint8_t scale_num) {
-    gyro_scale = (MPU6050_Scale)(scale_num & 3);
-    mpu6050_setscale_gyro(gyro_scale);
+void MPU6050::setscale_gyro(uint8_t scale_num) {
+    gyro_scale = scale_num & 3;
+    mpu6050_setscale_gyro((MPU6050_Scale)gyro_scale);
 }
 
-MPU6050::read(void) {
-    mpu6050_read(accel, gyro, &temp, accel_scale, gyro_scale);
+void MPU6050::read(void) {
+    mpu6050_read(accel, gyro, &temp, (MPU6050_Scale)accel_scale, (MPU6050_Scale)gyro_scale);
 }
     

--- a/i2c/mpu6050_i2c/mpu6050.hpp
+++ b/i2c/mpu6050_i2c/mpu6050.hpp
@@ -1,17 +1,24 @@
 /* class for using an MPU6050 IMU sensor on pi pico.
-An abstraction of pico example C code. */
+An abstraction of pico example C code. 
+TODO:
+    smart ptrs for results
+    C++ scale enums
+    mpu6050_t struct in C code for storing scales and bus addr
+ */
 #include "pico/stdlib.h"
 
 class MPU6050 {
     float *accel, *gyro, temp;
     uint8_t accel_scale, gyro_scale;
 public:
-    //const float *accel, *gyro, &chip_temp; // [m/s^2], [rad/s], [C]
-    const float &chip_temp;
-    MPU6050(void);
-    MPU6050(float *accel_out, float *gyro_out);
+    const float &chip_temp; // [C]
+
+    MPU6050(); //TODO
+    MPU6050(float *accel_out, float *gyro_out); // [m/s^2], [rad/s]
+
     void power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle);
     void reset(void);
+
     void setscale_accel(uint8_t scale_num); //scale 0-3 is 2g, 4g, 8g, or 16g
     void setscale_gyro(uint8_t scale_num); // scale 0-3 is 250, 500, 1000, or 2000 deg/s
     void read(void);

--- a/i2c/mpu6050_i2c/mpu6050.hpp
+++ b/i2c/mpu6050_i2c/mpu6050.hpp
@@ -1,10 +1,13 @@
 /* class for using an MPU6050 IMU sensor on pi pico.
 An abstraction of pico example C code. */
+#include "pico/stdlib.h"
 
 class MPU6050 {
     float *accel, *gyro, temp;
+    uint8_t accel_scale, gyro_scale;
 public:
-    const float &accel[3], &gyro[3], &chip_temp; // [m/s^2], [rad/s], [C]
+    //const float *accel, *gyro, &chip_temp; // [m/s^2], [rad/s], [C]
+    const float &chip_temp;
     MPU6050(void);
     MPU6050(float *accel_out, float *gyro_out);
     void power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle);
@@ -12,4 +15,4 @@ public:
     void setscale_accel(uint8_t scale_num); //scale 0-3 is 2g, 4g, 8g, or 16g
     void setscale_gyro(uint8_t scale_num); // scale 0-3 is 250, 500, 1000, or 2000 deg/s
     void read(void);
-}
+};

--- a/i2c/mpu6050_i2c/mpu6050.hpp
+++ b/i2c/mpu6050_i2c/mpu6050.hpp
@@ -1,0 +1,15 @@
+/* class for using an MPU6050 IMU sensor on pi pico.
+An abstraction of pico example C code. */
+
+class MPU6050 {
+    float *accel, *gyro, temp;
+public:
+    const float &accel[3], &gyro[3], &chip_temp; // [m/s^2], [rad/s], [C]
+    MPU6050(void);
+    MPU6050(float *accel_out, float *gyro_out);
+    void power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle);
+    void reset(void);
+    void setscale_accel(uint8_t scale_num); //scale 0-3 is 2g, 4g, 8g, or 16g
+    void setscale_gyro(uint8_t scale_num); // scale 0-3 is 250, 500, 1000, or 2000 deg/s
+    void read(void);
+}

--- a/i2c/mpu6050_i2c/mpu6050_i2c.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.c
@@ -10,6 +10,7 @@
 #include "pico/stdlib.h"
 #include "pico/binary_info.h"
 #include "hardware/i2c.h"
+#include "mpu6050_i2c.h"
 
 /* Example code to talk to a MPU6050 MEMS accelerometer and gyroscope
 
@@ -34,7 +35,6 @@ static uint8_t bus_addr = 0x68;
 // Register addresses in the MPU6050 to read and write data to
 const uint8_t REG_PWR_MGMT_1 = 0x6B, REG_ACCEL_OUT = 0x3B, REG_GYRO_OUT = 0x43, REG_TEMP_OUT = 0x41,
              REG_SIGNAL_PATH_RESET = 0x68, REG_GYRO_CONFIG = 0x1B, REG_ACCEL_CONFIG = 0x1C;
-typedef enum MPU6050_Scale {MPU_FS_0, MPU_FS_1, MPU_FS_2, MPU_FS_3} MPU6050_Scale;
 
 const float gyro_scale_deg[] = {250. / 0x7fff, 500. / 0x7fff, 1000. / 0x7fff, 2000. / 0x7fff};
 const float gyro_scale_rad[] = {M_PI / 180. * 250. / 0x7fff, M_PI / 180. * 500. / 0x7fff,
@@ -107,7 +107,7 @@ void mpu6050_read(float accel[3], float gyro_rad[3], float *temp, MPU6050_Scale 
     mpu6050_readreg16(REG_ACCEL_OUT, buffer, 7); //reads all at same time
     mpu6050_scale_accel(accel, buffer, accel_scale);
     if (temp) *temp = mpu6050_scale_temp(buffer[3]);
-    mpu6050_scale_gyro_rad(gyro, buffer + 4, gyro_scale);
+    mpu6050_scale_gyro_rad(gyro_rad, buffer + 4, gyro_scale);
 }
 
 // set and use sensitivity
@@ -141,7 +141,7 @@ float mpu6050_scale_temp(float temp_raw) {
 //TODO: read self test
 
 //TODO: functional mpu test
-int main() {
+int test() {
     stdio_init_all();
 #if !defined(i2c_default) || !defined(PICO_DEFAULT_I2C_SDA_PIN) || !defined(PICO_DEFAULT_I2C_SCL_PIN)
     #warning i2c/mpu6050_i2c example requires a board with I2C pins

--- a/i2c/mpu6050_i2c/mpu6050_i2c.h
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.h
@@ -1,0 +1,31 @@
+/* header for accessing mpu6050 functions in pico-examples
+
+Niraj Patel March 2022 */
+
+#include "pico/stdlib.h"
+#include "pico/binary_info.h"
+
+typedef enum MPU6050_Scale {MPU_FS_0, MPU_FS_1, MPU_FS_2, MPU_FS_3} MPU6050_Scale;
+
+// lower level functions for i2c
+void mpu6050_writereg(uint8_t reg, uint8_t value); //write one byte to a register
+void mpu6050_readreg(uint8_t reg, uint8_t *out, size_t length);
+void mpu6050_readreg16(uint8_t reg, uint16_t *out, size_t length);
+void mpu6050_setbusaddr(uint8_t addr); //set the i2c bus address for communication. MPU6050 must already have this value.
+
+// higher level mpu6050 functions
+void mpu6050_power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle); /* Set the power and clock settings.
+    CLKSEL is clock source, see docs. Recommended CLKSEL = 1 if gyro is enabled.
+    temp_disable disables temperature, sleep enables sleep mode, cycle wakes up only when converting. */
+void mpu6050_reset(); // Reset power management and signal path registers. MPU6050 returns to default settings.
+//set and use scaling
+void mpu6050_setscale_accel(MPU6050_Scale accel_scale);
+void mpu6050_setscale_gyro(MPU6050_Scale gyro_scale);
+void mpu6050_scale_accel(float accel[3], int16_t accel_raw[3], MPU6050_Scale scale); //sets accel[3] in m/s^2 from accel_raw[3]
+void mpu6050_scale_gyro_deg(float gyro[3], int16_t gyro_raw[3], MPU6050_Scale scale); //sets gyro[3] in degrees from gyro_raw[3]
+void mpu6050_scale_gyro_rad(float gyro[3], int16_t gyro_raw[3], MPU6050_Scale scale); //sets gyro[3] in radians from gyro_raw[3]
+float mpu6050_scale_temp(float temp_raw);
+
+void mpu6050_read_raw(int16_t accel[3], int16_t gyro[3], int16_t *temp); //read raw data values. Could read different timesteps.
+void mpu6050_read(float accel[3], float gyro[3], float *temp,
+                  MPU6050_Scale accel_scale, MPU6050_Scale gyro_scale); //reads all at same timestep, converts. temp can be NULL.

--- a/i2c/mpu6050_i2c/mpu6050_i2c.h
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.h
@@ -1,16 +1,18 @@
 /* header for accessing mpu6050 functions in pico-examples
 
 Niraj Patel March 2022 */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "pico/stdlib.h"
-#include "pico/binary_info.h"
 
 typedef enum MPU6050_Scale {MPU_FS_0, MPU_FS_1, MPU_FS_2, MPU_FS_3} MPU6050_Scale;
 
 // lower level functions for i2c
 void mpu6050_writereg(uint8_t reg, uint8_t value); //write one byte to a register
 void mpu6050_readreg(uint8_t reg, uint8_t *out, size_t length);
-void mpu6050_readreg16(uint8_t reg, uint16_t *out, size_t length);
+void mpu6050_readreg16(uint8_t reg, int16_t *out, size_t length);
 void mpu6050_setbusaddr(uint8_t addr); //set the i2c bus address for communication. MPU6050 must already have this value.
 
 // higher level mpu6050 functions
@@ -29,3 +31,7 @@ float mpu6050_scale_temp(float temp_raw);
 void mpu6050_read_raw(int16_t accel[3], int16_t gyro[3], int16_t *temp); //read raw data values. Could read different timesteps.
 void mpu6050_read(float accel[3], float gyro[3], float *temp,
                   MPU6050_Scale accel_scale, MPU6050_Scale gyro_scale); //reads all at same timestep, converts. temp can be NULL.
+
+#ifdef __cplusplus
+}
+#endif

--- a/i2c/mpu6050_i2c/mpu6050_i2c.h
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.h
@@ -11,15 +11,23 @@ typedef enum MPU6050_Scale {MPU_FS_0, MPU_FS_1, MPU_FS_2, MPU_FS_3} MPU6050_Scal
 
 // lower level functions for i2c
 void mpu6050_writereg(uint8_t reg, uint8_t value); //write one byte to a register
+//read length 8-bit integers from the register at reg, store them in *out.
 void mpu6050_readreg(uint8_t reg, uint8_t *out, size_t length);
+//read length 16-bit integers from the register at reg, store them in *out. Max length 32 (= 64 bytes)
 void mpu6050_readreg16(uint8_t reg, int16_t *out, size_t length);
 void mpu6050_setbusaddr(uint8_t addr); //set the i2c bus address for communication. MPU6050 must already have this value.
 
 // higher level mpu6050 functions
-void mpu6050_power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle); /* Set the power and clock settings.
+/* Set the power and clock settings.
     CLKSEL is clock source, see docs. Recommended CLKSEL = 1 if gyro is enabled.
     temp_disable disables temperature, sleep enables sleep mode, cycle wakes up only when converting. */
-void mpu6050_reset(); // Reset power management and signal path registers. MPU6050 returns to default settings.
+void mpu6050_power(uint8_t CLKSEL, bool temp_disable, bool sleep, bool cycle);
+// Reset power management and signal path registers. MPU6050 returns to default settings. Includes 200ms of wait.
+void mpu6050_reset();
+// turn on the mpu6050's accelerometer self test. Turn it off after a few 100ms with mpu6050_setscale_accel
+void mpu6050_accel_selftest_on();  // TODO: find out what "self test" does
+// turn on the mpu6050's gyroscope self test. Turn it off after a few 100ms with mpu6050_setscale_gyro
+void mpu6050_gyro_selftest_on();
 //set and use scaling
 void mpu6050_setscale_accel(MPU6050_Scale accel_scale);
 void mpu6050_setscale_gyro(MPU6050_Scale gyro_scale);
@@ -28,9 +36,13 @@ void mpu6050_scale_gyro_deg(float gyro[3], int16_t gyro_raw[3], MPU6050_Scale sc
 void mpu6050_scale_gyro_rad(float gyro[3], int16_t gyro_raw[3], MPU6050_Scale scale); //sets gyro[3] in radians from gyro_raw[3]
 float mpu6050_scale_temp(float temp_raw);
 
-void mpu6050_read_raw(int16_t accel[3], int16_t gyro[3], int16_t *temp); //read raw data values. Could read different timesteps.
+// core IMU reading functions
+void mpu6050_read_raw(int16_t accel[3], int16_t gyro[3], int16_t *temp); //read raw data values. Could read different samples.
 void mpu6050_read(float accel[3], float gyro[3], float *temp,
-                  MPU6050_Scale accel_scale, MPU6050_Scale gyro_scale); //reads all at same timestep, converts. temp can be NULL.
+                  MPU6050_Scale accel_scale, MPU6050_Scale gyro_scale); //reads all at same sample time, converts. temp can be NULL.
+
+bool setup_MPU6050_i2c(); //call this before using any other functions
+int run_MPU6050_demo();
 
 #ifdef __cplusplus
 }

--- a/i2c/mpu6050_i2c/mpu6050_i2c_main.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c_main.c
@@ -1,0 +1,16 @@
+/**
+ * Boilerplate main for mpu6050 I2c example
+ */
+
+#include <stdio.h>
+#include "pico/stdlib.h"
+#include "mpu6050_i2c.h"
+
+
+int main() {
+    stdio_init_all();
+    if (setup_MPU6050_i2c()) {
+        printf("Hello, MPU6050! Reading raw data from registers...\n");
+    }
+    return run_MPU6050_demo();
+}


### PR DESCRIPTION
I refactored and expanded the mpu6050_i2c example.  This adds new functions for MPU6050 features and clarifies existing ones. It also refactors the example into an MPU6050_i2c library and main.c. There are C and C++ versions of the library. I've been using the C++ library in another project for around a year.

I realize that this is a pretty drastic change, and moves the code away from its original intent as a pico code example. I plan on separating this into a dedicated mpu6050_i2c pico library. However, some of these changes could be useful for the pico-examples repo. Some possibilities are:

- Adding certain features like mpu6050_power and the scale functions
- Using only the refactor that defines constants for the register addresses
- Removing the C++ part, or moving it to another directory
- Refactoring out the library, so it's one .c and one .h file again

I'm happy to include any suggestions you have. 