### PR TITLE
Make the blink example work on Pico W

### DIFF
--- a/blink/CMakeLists.txt
+++ b/blink/CMakeLists.txt
@@ -5,6 +5,10 @@ add_executable(blink
 # pull in common dependencies
 target_link_libraries(blink pico_stdlib)
 
+if (PICO_CYW43_SUPPORTED)
+        target_link_libraries(blink pico_cyw43_arch_none)
+endif()
+
 # create map/bin/hex file etc.
 pico_add_extra_outputs(blink)
 

--- a/blink/CMakeLists.txt
+++ b/blink/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_executable(blink
-        blink.c
-        )
+    blink.c
+    )
 
 # pull in common dependencies
 target_link_libraries(blink pico_stdlib)
 
 if (PICO_CYW43_SUPPORTED)
-        target_link_libraries(blink pico_cyw43_arch_none)
+    target_link_libraries(blink pico_cyw43_arch_none)
 endif()
 
 # create map/bin/hex file etc.

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -6,18 +6,39 @@
 
 #include "pico/stdlib.h"
 
-int main() {
 #ifndef PICO_DEFAULT_LED_PIN
-#warning blink example requires a board with a regular LED
-#else
-    const uint LED_PIN = PICO_DEFAULT_LED_PIN;
-    gpio_init(LED_PIN);
-    gpio_set_dir(LED_PIN, GPIO_OUT);
-    while (true) {
-        gpio_put(LED_PIN, 1);
-        sleep_ms(250);
-        gpio_put(LED_PIN, 0);
-        sleep_ms(250);
-    }
+#include "pico/cyw43_arch.h"
 #endif
+
+#ifndef LED_DELAY_MS
+#define LED_DELAY_MS 250
+#endif
+
+int pico_led_init(void) {
+#if defined(PICO_DEFAULT_LED_PIN)
+    gpio_init(PICO_DEFAULT_LED_PIN);
+    gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+    return PICO_OK;
+#elif defined(CYW43_WL_GPIO_LED_PIN)
+    return cyw43_arch_init();
+#endif
+}
+
+void pico_set_led(bool led_on) {
+#if defined(PICO_DEFAULT_LED_PIN)
+    gpio_put(PICO_DEFAULT_LED_PIN, led_on);
+#elif defined(CYW43_WL_GPIO_LED_PIN)
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
+#endif
+}
+
+int main() {
+    int rc = pico_led_init();
+    hard_assert(rc == PICO_OK);
+    while (true) {
+        pico_set_led(true);
+        sleep_ms(LED_DELAY_MS);
+        pico_set_led(false);
+        sleep_ms(LED_DELAY_MS);
+    }
 }

--- a/blink/blink.c
+++ b/blink/blink.c
@@ -6,7 +6,9 @@
 
 #include "pico/stdlib.h"
 
-#ifndef PICO_DEFAULT_LED_PIN
+// Pico W devices use a GPIO on the WIFI chip for the LED,
+// so when building for Pico W, CYW43_WL_GPIO_LED_PIN will be defined
+#ifdef CYW43_WL_GPIO_LED_PIN
 #include "pico/cyw43_arch.h"
 #endif
 
@@ -14,20 +16,27 @@
 #define LED_DELAY_MS 250
 #endif
 
+// Perform initialisation
 int pico_led_init(void) {
 #if defined(PICO_DEFAULT_LED_PIN)
+    // A device like Pico that uses a GPIO for the LED will define PICO_DEFAULT_LED_PIN
+    // so we can use normal GPIO functionality to turn the led on and off
     gpio_init(PICO_DEFAULT_LED_PIN);
     gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
     return PICO_OK;
 #elif defined(CYW43_WL_GPIO_LED_PIN)
+    // For Pico W devices we need to initialise the driver etc
     return cyw43_arch_init();
 #endif
 }
 
+// Turn the led on or off
 void pico_set_led(bool led_on) {
 #if defined(PICO_DEFAULT_LED_PIN)
+    // Just set the GPIO on or off
     gpio_put(PICO_DEFAULT_LED_PIN, led_on);
 #elif defined(CYW43_WL_GPIO_LED_PIN)
+    // Ask the wifi "driver" to set the GPIO on or off
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
 #endif
 }


### PR DESCRIPTION
It seems to confuse people that the blink example doesn't work on PicoW. To avoid further confusion, make it work, rather than build and silently do nothing.

Fixes #421