### PR TITLE
Add a picow_blink_fast_clock example

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ App|Description
 ---|---
 [picow_access_point](pico_w/wifi/access_point) | Starts a WiFi access point, and fields DHCP requests.
 [picow_blink](pico_w/wifi/blink) | Blinks the on-board LED (which is connected via the WiFi chip).
-[picow_blink_slow_clock](pico_w/wifi/blink_slow_clock) | Blinks the on-board LED (which is connected via the WiFi chip) with a slower system clock to show how to reconfigure communication with the WiFi chip under those circumstances
-[picow_blink_fast_clock](pico_w/wifi/blink_slow_clock) | Blinks the on-board LED (which is connected via the WiFi chip) with a faster system clock to show how to reconfigure communication with the WiFi chip under those circumstances
+[picow_blink_slow_clock](pico_w/wifi/blink) | Blinks the on-board LED (which is connected via the WiFi chip) with a slower system clock to show how to reconfigure communication with the WiFi chip at run time under those circumstances
+[picow_blink_fast_clock](pico_w/wifi/blink) | Blinks the on-board LED (which is connected via the WiFi chip) with a faster system clock to show how to reconfigure communication with the WiFi chip at build time under those circumstances
 [picow_iperf_server](pico_w/wifi/iperf) | Runs an "iperf" server for WiFi speed testing.
 [picow_ntp_client](pico_w/wifi/ntp_client) | Connects to an NTP server to fetch and display the current time.
 [picow_tcp_client](pico_w/wifi/tcp_client) | A simple TCP client. You can run [python_test_tcp_server.py](pico_w/wifi/python_test_tcp/python_test_tcp_server.py) for it to connect to.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ App|Description
 [picow_access_point](pico_w/wifi/access_point) | Starts a WiFi access point, and fields DHCP requests.
 [picow_blink](pico_w/wifi/blink) | Blinks the on-board LED (which is connected via the WiFi chip).
 [picow_blink_slow_clock](pico_w/wifi/blink_slow_clock) | Blinks the on-board LED (which is connected via the WiFi chip) with a slower system clock to show how to reconfigure communication with the WiFi chip under those circumstances
+[picow_blink_fast_clock](pico_w/wifi/blink_slow_clock) | Blinks the on-board LED (which is connected via the WiFi chip) with a faster system clock to show how to reconfigure communication with the WiFi chip under those circumstances
 [picow_iperf_server](pico_w/wifi/iperf) | Runs an "iperf" server for WiFi speed testing.
 [picow_ntp_client](pico_w/wifi/ntp_client) | Connects to an NTP server to fetch and display the current time.
 [picow_tcp_client](pico_w/wifi/tcp_client) | A simple TCP client. You can run [python_test_tcp_server.py](pico_w/wifi/python_test_tcp/python_test_tcp_server.py) for it to connect to.

--- a/pico_w/wifi/blink/CMakeLists.txt
+++ b/pico_w/wifi/blink/CMakeLists.txt
@@ -31,3 +31,24 @@ pico_add_extra_outputs(picow_blink_slow_clock)
 
 # add url via pico_set_program_url
 example_auto_set_url(picow_blink_slow_clock)
+
+# This version should behave exactly the same, but it runs the sys clock slowly.
+add_executable(picow_blink_fast_clock
+        picow_blink_fast_clock.c
+        )
+target_link_libraries(picow_blink_fast_clock
+        pico_stdlib              # for core functionality
+        pico_cyw43_arch_none     # we need Wifi to access the GPIO, but we don't need anything else
+        hardware_clocks
+        )
+# This requires us to modify the pio divisor to successfully communicate with the cyw43 chip
+target_compile_definitions(picow_blink_fast_clock PRIVATE
+        CYW43_PIO_CLOCK_DIV_INT=4
+        CYW43_PIO_CLOCK_DIV_FRAC=0
+        )
+
+# create map/bin/hex file etc.
+pico_add_extra_outputs(picow_blink_fast_clock)
+
+# add url via pico_set_program_url
+example_auto_set_url(picow_blink_fast_clock)

--- a/pico_w/wifi/blink/CMakeLists.txt
+++ b/pico_w/wifi/blink/CMakeLists.txt
@@ -12,7 +12,7 @@ pico_add_extra_outputs(picow_blink)
 # add url via pico_set_program_url
 example_auto_set_url(picow_blink)
 
-# This version should behave exactly the same, but it runs the sys clock slowly.
+# This version should behave exactly the same, but it runs the sys clock slower and changes the pio pio clock divisor for the cyw43 driver at run time.
 add_executable(picow_blink_slow_clock
         picow_blink_slow_clock.c
         )
@@ -32,7 +32,7 @@ pico_add_extra_outputs(picow_blink_slow_clock)
 # add url via pico_set_program_url
 example_auto_set_url(picow_blink_slow_clock)
 
-# This version should behave exactly the same, but it runs the sys clock slowly.
+# This version should behave exactly the same, but it runs the sys clock faster and changes the pio pio clock divisor for the cyw43 driver at build time.
 add_executable(picow_blink_fast_clock
         picow_blink_fast_clock.c
         )
@@ -44,7 +44,7 @@ target_link_libraries(picow_blink_fast_clock
 # This requires us to modify the pio divisor to successfully communicate with the cyw43 chip
 target_compile_definitions(picow_blink_fast_clock PRIVATE
         CYW43_PIO_CLOCK_DIV_INT=4
-        CYW43_PIO_CLOCK_DIV_FRAC=0
+        CYW43_PIO_CLOCK_DIV_FRAC8=0
         )
 
 # create map/bin/hex file etc.

--- a/pico_w/wifi/blink/picow_blink_fast_clock.c
+++ b/pico_w/wifi/blink/picow_blink_fast_clock.c
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2024 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/stdlib.h"
+#include "pico/cyw43_arch.h"
+#include "pico/cyw43_driver.h"
+#include "hardware/clocks.h"
+
+int main() {
+    // Increase sys clock. We have slowed down the cyw43 pio to compensate using CYW43_PIO_CLOCK_DIV_INT=4 CYW43_PIO_CLOCK_DIV_FRAC=0 in the cmake file
+    // By default the pio used to communicate with cyw43 runs with a clock divisor of 2
+    // if you modify the clock you will have to compensate for this
+    // As an alternative you could specify CYW43_PIO_CLOCK_DIV_DYNAMIC=1 in your cmake file and call cyw43_set_pio_clock_divisor(4, 0)
+    set_sys_clock_khz(266000, true);
+
+    stdio_init_all();
+    if (cyw43_arch_init()) {
+        printf("Wi-Fi init failed");
+        return -1;
+    }
+    while (true) {
+        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
+        sleep_ms(250);
+        cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 0);
+        sleep_ms(250);
+    }
+}


### PR DESCRIPTION
We have picow_blink_slow_clock, so we probably need an example of running it faster?