### PR TITLE
Skip encrypted bootloader with no mbedtls

### DIFF
--- a/bootloaders/CMakeLists.txt
+++ b/bootloaders/CMakeLists.txt
@@ -1,1 +1,6 @@
-add_subdirectory_exclude_platforms(encrypted host rp2040 rp2350-riscv)
+if (TARGET pico_mbedtls)
+    add_subdirectory_exclude_platforms(encrypted host rp2040 rp2350-riscv)
+else()
+    # Assume picotool has no signing support, if no pico_mbedtls available
+    message("Skipping encrypted bootloader example as pico_mbedtls unavailable")
+endif ()


### PR DESCRIPTION
Currently, a pico-examples build without the mbedtls submodule checked out in the SDK will fail, as picotool throws
```
ERROR: Cannot sign/hash partition table with no mbedtls
```
when making `enc_bootloader`, due to being compiled without mbedtls

Solve this by skipping `enc_bootloader` when there is no `pico_mbedtls`