### PR TITLE
Fix pin ordering for pins with names in pio_spi_flash

### DIFF
--- a/pio/spi/spi_flash.c
+++ b/pio/spi/spi_flash.c
@@ -128,7 +128,10 @@ int main() {
                  PICO_DEFAULT_SPI_RX_PIN
     );
     // Make the 'SPI' pins available to picotool
-    bi_decl(bi_4pins_with_names(PICO_DEFAULT_SPI_RX_PIN, "SPI RX", PICO_DEFAULT_SPI_TX_PIN, "SPI TX", PICO_DEFAULT_SPI_SCK_PIN, "SPI SCK", PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_RX_PIN, "SPI RX"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_TX_PIN, "SPI TX"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_SCK_PIN, "SPI SCK"));
+    bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
 
     uint8_t page_buf[FLASH_PAGE_SIZE];
 


### PR DESCRIPTION
`bi_4pins_with_names` does not have any ordering as it's a pin mask, so the pins must be in order, which cannot be guaranteed here depending on the default pins. This causes the names to appear next to the wrong pins in `picotool info`

Eg for pico, with
```
#define PICO_DEFAULT_SPI_SCK_PIN 18
#define PICO_DEFAULT_SPI_TX_PIN 19
#define PICO_DEFAULT_SPI_RX_PIN 16
#define PICO_DEFAULT_SPI_CSN_PIN 17
```
`picotool info -p` shows
```
16:  SPI RX
17:  SPI TX
18:  SPI SCK
19:  SPI CS
```

This will throw a compilation error once [pico-sdk/#1791](https://github.com/raspberrypi/pico-sdk/pull/1791) is merged, so this should be merged before that

Switch to 4 spearate `bi_1pin_with_name` to ensure the right name matches the right pin