### PR TITLE
Workaround gcc/newlib issue on Ubuntu 24

### DIFF
--- a/sha/mbedtls_sha256/mbedtls_sha256.c
+++ b/sha/mbedtls_sha256/mbedtls_sha256.c
@@ -6,6 +6,9 @@
 
 #include <stdio.h>
 #include <string.h>
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIu64
+#include <sys/types.h>
 #include <inttypes.h>
 #include <stdlib.h>
 

--- a/sha/sha256/hello_sha256.c
+++ b/sha/sha256/hello_sha256.c
@@ -6,6 +6,9 @@
 
 #include <stdio.h>
 #include <string.h>
+// Include sys/types.h before inttypes.h to work around issue with
+// certain versions of GCC and newlib which causes omission of PRIu64
+#include <sys/types.h>
 #include <inttypes.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-examples/issues/520 and https://github.com/raspberrypi/pico-examples/commit/8953e1b75a5b4f3d28533e3e04f6767a465625f9

(and also https://github.com/raspberrypi/pico-sdk/pull/1863 )