### PR TITLE
Fix typo in macro definition

### DIFF
--- a/freertos/hello_freertos/hello_freertos.c
+++ b/freertos/hello_freertos/hello_freertos.c
@@ -22,7 +22,7 @@
 #endif
 
 // Whether to flash the led
-#ifndef USB_LED
+#ifndef USE_LED
 #define USE_LED 1
 #endif
 


### PR DESCRIPTION
`s/USB_LED/USE_LED/`