### PR TITLE
Fix picotool_DIR and pioasm_DIR passing to universal build

### DIFF
--- a/universal/CMakeLists.txt
+++ b/universal/CMakeLists.txt
@@ -48,6 +48,11 @@ function (add_universal_target TARGET SOURCE)
     endif()
 
     add_custom_target(${TARGET} ALL)
+    if (picotool_DIR)
+        set(universal_picotool_DIR ${picotool_DIR})
+    else()
+        set(universal_picotool_DIR ${picotool_INSTALL_DIR}/picotool)
+    endif()
 
     set(DEPS "")
     set(BINS "")
@@ -70,7 +75,7 @@ function (add_universal_target TARGET SOURCE)
                 "-DUNIVERSAL_PROJECT_DIR:FILEPATH=${SOURCE}"
                 "-DUNIVERSAL_BINARY_DIR:FILEPATH=${CMAKE_CURRENT_BINARY_DIR}/${TARGET}/${platform}"
                 "-DSOURCE_TARGET=${SOURCE_TARGET}"
-                "-Dpicotool_DIR=${picotool_INSTALL_DIR}/picotool"
+                "-Dpicotool_DIR=${universal_picotool_DIR}"
                 "-Dpioasm_DIR=${PIOASM_INSTALL_DIR}/pioasm"
             BUILD_ALWAYS 1 # force dependency checking
             INSTALL_COMMAND ""

--- a/universal/CMakeLists.txt
+++ b/universal/CMakeLists.txt
@@ -53,6 +53,11 @@ function (add_universal_target TARGET SOURCE)
     else()
         set(universal_picotool_DIR ${picotool_INSTALL_DIR}/picotool)
     endif()
+    if (pioasm_DIR)
+        set(universal_pioasm_DIR ${pioasm_DIR})
+    else()
+        set(universal_pioasm_DIR ${PIOASM_INSTALL_DIR}/pioasm)
+    endif()
 
     set(DEPS "")
     set(BINS "")
@@ -76,7 +81,7 @@ function (add_universal_target TARGET SOURCE)
                 "-DUNIVERSAL_BINARY_DIR:FILEPATH=${CMAKE_CURRENT_BINARY_DIR}/${TARGET}/${platform}"
                 "-DSOURCE_TARGET=${SOURCE_TARGET}"
                 "-Dpicotool_DIR=${universal_picotool_DIR}"
-                "-Dpioasm_DIR=${PIOASM_INSTALL_DIR}/pioasm"
+                "-Dpioasm_DIR=${universal_pioasm_DIR}"
             BUILD_ALWAYS 1 # force dependency checking
             INSTALL_COMMAND ""
             )


### PR DESCRIPTION
If pictool_DIR is set then pass that, otherwise pass the picotool_INSTALL_DIR, which is only set when picotool is built as part of the SDK

Fixes #531 I think - although @lurch should probably double check