### PR TITLE
Copy hello_serial into bootloaders/encrypted

### DIFF
--- a/bootloaders/encrypted/CMakeLists.txt
+++ b/bootloaders/encrypted/CMakeLists.txt
@@ -64,7 +64,7 @@ example_auto_set_url(enc_bootloader)
 
 # Example binary to load
 add_executable(hello_serial_enc
-        ../../hello_world/serial/hello_serial.c
+        hello_serial.c
         )
 
 # pull in common dependencies

--- a/bootloaders/encrypted/hello_serial.c
+++ b/bootloaders/encrypted/hello_serial.c
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include "pico/stdlib.h"
+
+int main() {
+    stdio_init_all();
+    while (true) {
+        printf("Hello, world!\n");
+        printf("I'm an encrypted binary\n");
+        sleep_ms(1000);
+    }
+}


### PR DESCRIPTION
Removes the dependence on a file from a separate folder, which other examples don't have

This would allow the example to be used in the VS Code extension, as that needs examples to be contained in a single directory