### PR TITLE
Fix quadrature_encoder examples on rp2350

### DIFF
--- a/pio/quadrature_encoder/quadrature_encoder.c
+++ b/pio/quadrature_encoder/quadrature_encoder.c
@@ -34,12 +34,14 @@
 
 int main() {
     int new_value, delta, old_value = 0;
+    int last_value = -1, last_delta = -1;
 
     // Base pin to connect the A phase of the encoder.
     // The B phase must be connected to the next pin
     const uint PIN_AB = 10;
 
     stdio_init_all();
+    printf("Hello from quadrature encoder\n");
 
     PIO pio = pio0;
     const uint sm = 0;
@@ -56,7 +58,11 @@ int main() {
         delta = new_value - old_value;
         old_value = new_value;
 
-        printf("position %8d, delta %6d\n", new_value, delta);
+        if (new_value != last_value || delta != last_delta ) {
+            printf("position %8d, delta %6d\n", new_value, delta);
+            last_value = new_value;
+            last_delta = delta;
+        }
         sleep_ms(100);
     }
 }

--- a/pio/quadrature_encoder/quadrature_encoder.pio
+++ b/pio/quadrature_encoder/quadrature_encoder.pio
@@ -99,6 +99,9 @@ increment_cont:
 static inline void quadrature_encoder_program_init(PIO pio, uint sm, uint pin, int max_step_rate)
 {
     pio_sm_set_consecutive_pindirs(pio, sm, pin, 2, false);
+    pio_gpio_init(pio, pin);
+    pio_gpio_init(pio, pin + 1);
+
     gpio_pull_up(pin);
     gpio_pull_up(pin + 1);
 

--- a/pio/quadrature_encoder_substep/quadrature_encoder_substep.c
+++ b/pio/quadrature_encoder_substep/quadrature_encoder_substep.c
@@ -368,9 +368,10 @@ int main(void)
 
     // base pin to connect the A phase of the encoder. the B phase must be
     // connected to the next pin
-    const uint PIN_A = 2;
+    const uint PIN_A = 10;
 
     stdio_init_all();
+    printf("Hello from quadrature encoder substep\n");
 
     PIO pio = pio0;
     const uint sm = 0;

--- a/pio/quadrature_encoder_substep/quadrature_encoder_substep.pio
+++ b/pio/quadrature_encoder_substep/quadrature_encoder_substep.pio
@@ -133,6 +133,8 @@ invalid:
 static inline void quadrature_encoder_substep_program_init(PIO pio, uint sm, uint pin_A)
 {
 	uint pin_state, position, ints;
+	pio_gpio_init(pio, pin_A);
+	pio_gpio_init(pio, pin_A + 1);
 
 	pio_sm_set_consecutive_pindirs(pio, sm, pin_A, 2, false);
 	gpio_pull_up(pin_A);


### PR DESCRIPTION
Have to initialise the gpio function for rp2350.
Stop the quadrature_encoder example spamming sdio if nothing has changed.
Change the pins used for quadrature_encoder_substep so they match the other example.

Fixes #550