### PR TITLE
Check rows before running hello_otp example

### DIFF
--- a/otp/hello_otp/hello_otp.c
+++ b/otp/hello_otp/hello_otp.c
@@ -20,6 +20,25 @@ int main() {
     // Row to write raw data
     uint16_t raw_row = 0x410;
 
+    // Check rows are empty - else the rest of the tests won't behave as expected
+    unsigned char initial_data[32] = {0};
+    cmd.flags = ecc_row;
+    ret = rom_func_otp_access(initial_data, sizeof(initial_data)/2, cmd);
+    if (ret) {
+        printf("ERROR: Initial ECC Row Read failed with error %d\n", ret);
+    }
+    cmd.flags = raw_row;
+    ret = rom_func_otp_access(initial_data+(sizeof(initial_data)/2), sizeof(initial_data)/2, cmd);
+    if (ret) {
+        printf("ERROR: Initial Raw Row Read failed with error %d\n", ret);
+    }
+    for (int i=0; i < sizeof(initial_data); i++) {
+        if (initial_data[i] != 0) {
+            printf("ERROR: This example requires empty OTP rows to run - change the ecc_row and raw_row variables to an empty row and recompile\n");
+            return 0;
+        }
+    }
+
     if (ecc_row) {
         // Write an ECC value to OTP - the buffer must have a multiple of 2 length for ECC data
         unsigned char ecc_write_data[16] = "Hello from OTP";


### PR DESCRIPTION
Check that the OTP rows being used for the hello_otp example are 0 before the example starts, else the example will throw other errors. This was prompted by #554, so it will now throw an error in that case explaining that the rows need to be changed.