### PR TITLE
Updated FREE_RTOS_KERNEL_SMP comment to be applicable to any 2 core RP chip

### DIFF
--- a/freertos/FreeRTOSConfig_examples_common.h
+++ b/freertos/FreeRTOSConfig_examples_common.h
@@ -102,7 +102,7 @@
 #define configMAX_API_CALL_INTERRUPT_PRIORITY   [dependent on processor and application]
 */
 
-#if FREE_RTOS_KERNEL_SMP // set by the RP2040 SMP port of FreeRTOS
+#if FREE_RTOS_KERNEL_SMP // set by the RP2xxx SMP port of FreeRTOS
 /* SMP port only */
 #ifndef configNUMBER_OF_CORES
 #define configNUMBER_OF_CORES                   2


### PR DESCRIPTION
Current wording implied it would only be set for the RP2040 port code and the [RP2350 port](https://github.com/raspberrypi/FreeRTOS-Kernel/blob/main/portable/ThirdParty/GCC/RP2350_ARM_NTZ/library.cmake#L44) appears to have defined it on master.
