### PR TITLE
Update mpu6050_i2c.c

### DIFF
--- a/i2c/mpu6050_i2c/mpu6050_i2c.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.c
@@ -39,6 +39,12 @@ static void mpu6050_reset() {
     // There are a load more options to set up the device in different ways that could be added here
     uint8_t buf[] = {0x6B, 0x80};
     i2c_write_blocking(i2c_default, addr, buf, 2, false);
+    sleep_ms(100); // Allow device to reset and stabilize
+
+    // Clear sleep mode (0x6B register, 0x00 value)
+    buf[1] = 0x00;  // Clear sleep mode by writing 0x00 to the 0x6B register
+    i2c_write_blocking(i2c_default, addr, buf, 2, false); 
+    sleep_ms(10); // Allow stabilization after waking up
 }
 
 static void mpu6050_read_raw(int16_t accel[3], int16_t gyro[3], int16_t *temp) {


### PR DESCRIPTION
Explanation of Changes:
The first part of the function resets the MPU6050 by writing 0x80 to the 0x6B register, which is the reset command. After a short delay (100 ms) to allow the reset to take effect, the second part writes 0x00 to the 0x6B register to clear the sleep mode and wake up the device. A short 10 ms delay is added after clearing the sleep mode to allow the device to stabilize.