### PR TITLE
Fix using stdio_usb and other interrupts from encrypted binaries

### DIFF
--- a/bootloaders/encrypted/hello_serial.c
+++ b/bootloaders/encrypted/hello_serial.c
@@ -9,7 +9,7 @@
 #include "hardware/sync.h"
 
 int main() {
-    restore_interrupts_from_disabled(0);
+    enable_interrupts();
     stdio_init_all();
     while (true) {
         printf("Hello, world!\n");

--- a/bootloaders/encrypted/hello_serial.c
+++ b/bootloaders/encrypted/hello_serial.c
@@ -6,8 +6,10 @@
 
 #include <stdio.h>
 #include "pico/stdlib.h"
+#include "hardware/sync.h"
 
 int main() {
+    restore_interrupts_from_disabled(0);
     stdio_init_all();
     while (true) {
         printf("Hello, world!\n");


### PR DESCRIPTION
This is a fix for #584, to enable the interrupts in the encrypted binary, which then allows use of `stdio_usb` if desired