### PR TITLE
Warn when using blink_simple without PICO_DEFAULT_LED_PIN

### DIFF
--- a/blink_simple/blink_simple.c
+++ b/blink_simple/blink_simple.c
@@ -10,6 +10,10 @@
 #define LED_DELAY_MS 250
 #endif
 
+#ifndef PICO_DEFAULT_LED_PIN
+#warning blink_simple example requires a board with a regular LED
+#endif
+
 // Initialize the GPIO for the LED
 void pico_led_init(void) {
 #ifdef PICO_DEFAULT_LED_PIN


### PR DESCRIPTION
The `blink_simple` example won't do anything without `PICO_DEFAULT_LED_PIN` defined, so the compilation should raise a warning similar to other examples that rely on `PICO_DEFAULT_LED_PIN` (eg `blinky`, `hello_pio`) when it's not defined.

Prompted by https://github.com/raspberrypi/pico-vscode/issues/152