### PR TITLE
Add NIST curves optimizations to shared mbedtls config

### DIFF
--- a/pico_w/wifi/mbedtls_config_examples_common.h
+++ b/pico_w/wifi/mbedtls_config_examples_common.h
@@ -68,4 +68,7 @@
 #define MBEDTLS_PEM_PARSE_C
 #define MBEDTLS_BASE64_C
 
+// The following significantly speeds up mbedtls due to NIST optimizations.
+#define MBEDTLS_ECP_NIST_OPTIM
+
 #endif


### PR DESCRIPTION
This PR enables NIST curve optimizations in shared mbedtls config, which significantly speed up TLS handshakes and communication by 4x to 8x. ([mbedtls docs](https://mbed-tls.readthedocs.io/projects/api/en/development/api/file/crypto__config_8h/#c.MBEDTLS_ECP_NIST_OPTIM))

[Issue#411](https://github.com/raspberrypi/pico-examples/issues/411#issuecomment-2607216547)