### PR TITLE
put_pixel in the parallel example sets the color order for the pixel to BRG instead GRB

### DIFF
--- a/pio/ws2812/ws2812_parallel.c
+++ b/pio/ws2812/ws2812_parallel.c
@@ -29,16 +29,16 @@ static uint8_t *current_strip_out;
 static bool current_strip_4color;
 
 static inline void put_pixel(uint32_t pixel_grb) {
-    *current_strip_out++ = pixel_grb & 0xffu;
-    *current_strip_out++ = (pixel_grb >> 8u) & 0xffu;
     *current_strip_out++ = (pixel_grb >> 16u) & 0xffu;
+    *current_strip_out++ = (pixel_grb >> 8u) & 0xffu;
+    *current_strip_out++ = pixel_grb & 0xffu;
     if (current_strip_4color) {
-        *current_strip_out++ = 0; // todo adjust?
+        *current_strip_out++ = 0;  // todo adjust?
     }
 }
 
 static inline uint32_t urgb_u32(uint8_t r, uint8_t g, uint8_t b) {
-    return
+    return 
             ((uint32_t) (r) << 8) |
             ((uint32_t) (g) << 16) |
             (uint32_t) (b);


### PR DESCRIPTION
The data sheets for the ws2812 and ws2812b led strips (e.g., https://cdn-shop.adafruit.com/datasheets/WS2812.pdf) show that the required color order when sending data is GRB. The `put_pixel` function in `ws2812_parallel.c` inverts the order of the colors when putting data into a strip, so you end up with BRG, which means that your colors end up being weird or, at least, not what you expected.

Reversing the order of the additions to `current_strip_out` solves the problem.