### PR TITLE
Change TLS example URL

### DIFF
--- a/pico_w/wifi/tls_client/picow_tls_client.c
+++ b/pico_w/wifi/tls_client/picow_tls_client.c
@@ -7,8 +7,8 @@
 #include "pico/stdlib.h"
 #include "pico/cyw43_arch.h"
 
-#define TLS_CLIENT_SERVER        "worldtimeapi.org"
-#define TLS_CLIENT_HTTP_REQUEST  "GET /api/ip HTTP/1.1\r\n" \
+#define TLS_CLIENT_SERVER        "fw-download-alias1.raspberrypi.com"
+#define TLS_CLIENT_HTTP_REQUEST  "GET /net_install/boot.sig HTTP/1.1\r\n" \
                                  "Host: " TLS_CLIENT_SERVER "\r\n" \
                                  "Connection: close\r\n" \
                                  "\r\n"


### PR DESCRIPTION
Change the TLS example to use our download server. worldtimeapi.org seems to be unreliable and it's a bit impolite to hit their server in our examples.