### PR TITLE
Fix workflows for new mbedtls

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Checkout pico-sdk submodules
       working-directory: ${{github.workspace}}/pico-sdk
-      run: git submodule update --init
+      run: git submodule update --init --recursive
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Checkout pico-sdk submodules
         working-directory: ${{github.workspace}}/pico-sdk
-        run: git submodule update --init
+        run: git submodule update --init --recursive
       - name: Install dependencies
         run: |
           brew install cmake

--- a/.github/workflows/multi-gcc.yml
+++ b/.github/workflows/multi-gcc.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Checkout pico-sdk submodules
       working-directory: ${{github.workspace}}/pico-sdk
-      run: git submodule update --init
+      run: git submodule update --init --recursive
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Checkout pico-sdk submodules
         working-directory: ${{github.workspace}}/pico-sdk
-        run: git submodule update --init
+        run: git submodule update --init --recursive
 
       - name: Install dependencies
         working-directory: ${{github.workspace}}/pico-examples


### PR DESCRIPTION
Anything that builds picotool now has to pass "recursive" flag to the "git submodule init" command