### PR TITLE
Add separate builds for Pico and Pico 2 W to GiHub CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,28 +33,43 @@ jobs:
       working-directory: ${{github.workspace}}/pico-sdk
       run: git submodule update --init
 
-    - name: Create Build Environment
+    - name: Create Build Environment (Pico)
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
       working-directory: ${{github.workspace}}/pico-examples
-      run:  cmake -E make_directory ${{github.workspace}}/pico-examples/build
+      run:  cmake -E make_directory ${{github.workspace}}/pico-examples/build.pico
 
-    - name: Configure CMake
+    - name: Configure CMake (Pico)
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
-      working-directory: ${{github.workspace}}/pico-examples/build
+      working-directory: ${{github.workspace}}/pico-examples/build.pico
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: PICO_SDK_PATH=../../pico-sdk cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: PICO_SDK_PATH=../../pico-sdk cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPICO_BOARD=pico
 
     - name: Get core count
       id: core_count
       run : cat /proc/cpuinfo  | grep processor | wc -l
 
-    - name: Build
-      working-directory: ${{github.workspace}}/pico-examples/build
+    - name: Build (Pico)
+      working-directory: ${{github.workspace}}/pico-examples/build.pico
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE --parallel $(nproc)
+
+    - name: Create Build Environment (Pico 2 W)
+      working-directory: ${{github.workspace}}/pico-examples
+      run:  cmake -E make_directory ${{github.workspace}}/pico-examples/build.pico2_w
+
+    - name: Configure CMake (Pico 2 W)
+      shell: bash
+      working-directory: ${{github.workspace}}/pico-examples/build.pico2_w
+      run: PICO_SDK_PATH=../../pico-sdk cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPICO_BOARD=pico2_w
+
+    - name: Build (Pico 2 W)
+      working-directory: ${{github.workspace}}/pico-examples/build.pico2_w
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE --parallel $(nproc)


### PR DESCRIPTION
Many of the pico-examples are RP2350 only, so add a Pico 2 W build job so that these (and the wireless-only examples) get test-built too