### PR TITLE
Remove ninja from choco_packages.config

### DIFF
--- a/.github/workflows/choco_packages.config
+++ b/.github/workflows/choco_packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="gcc-arm-embedded" version="10.2.1" />
   <package id="mingw" version="12.2.0" />
-  <package id="ninja" version="1.11.1" />
 </packages>


### PR DESCRIPTION
Ninja is now preinstalled on GitHub Windows runners (https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md), so don't install it separately to prevent downgrade errors.