### PR TITLE
Allow enc_bootloader on older clang

### DIFF
--- a/bootloaders/CMakeLists.txt
+++ b/bootloaders/CMakeLists.txt
@@ -1,10 +1,5 @@
 if (TARGET pico_mbedtls)
-    # older clang seem to have a segment overlap issue that confuses picotool
-    if (PICO_C_COMPILER_IS_CLANG AND CMAKE_C_COMPILER_VERSION VERSION_LESS "17.0.0")
-        message("Skipping encrypted bootloader example on LLVM/Clang version < 17; please use GCC or newer LLVM/Clang")
-    else()
-        add_subdirectory_exclude_platforms(encrypted host rp2040 rp2350-riscv)
-    endif()
+    add_subdirectory_exclude_platforms(encrypted host rp2040 rp2350-riscv)
 else()
     # Assume picotool has no signing support, if no pico_mbedtls available
     message("Skipping encrypted bootloader example as pico_mbedtls unavailable")

--- a/bootloaders/encrypted/CMakeLists.txt
+++ b/bootloaders/encrypted/CMakeLists.txt
@@ -10,8 +10,6 @@ target_link_libraries(enc_bootloader pico_stdlib pico_rand pico_mbedtls)
 # use stack guards, as AES variables are written near the stack
 target_compile_definitions(enc_bootloader PRIVATE PICO_USE_STACK_GUARDS=1)
 
-target_link_options(enc_bootloader PUBLIC -Wl,--print-memory-usage)
-
 target_include_directories(enc_bootloader PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 # set as no_flash binary


### PR DESCRIPTION
Once https://github.com/raspberrypi/picotool/pull/243 is merged, the enc_bootloader example will work with older clang again