### PR TITLE
PIO I2C example: clear ISR counter on each start/repstart

### DIFF
--- a/pio/i2c/pio_i2c.c
+++ b/pio/i2c/pio_i2c.c
@@ -67,9 +67,10 @@ uint8_t pio_i2c_get(PIO pio, uint sm) {
 }
 
 void pio_i2c_start(PIO pio, uint sm) {
-    pio_i2c_put_or_err(pio, sm, 1u << PIO_I2C_ICOUNT_LSB); // Escape code for 2 instruction sequence
+    pio_i2c_put_or_err(pio, sm, 2u << PIO_I2C_ICOUNT_LSB);                         // Escape code for 3 instruction sequence
     pio_i2c_put_or_err(pio, sm, set_scl_sda_program_instructions[I2C_SC1_SD0]);    // We are already in idle state, just pull SDA low
     pio_i2c_put_or_err(pio, sm, set_scl_sda_program_instructions[I2C_SC0_SD0]);    // Also pull clock low so we can present data
+    pio_i2c_put_or_err(pio, sm, pio_encode_mov(pio_isr, pio_null));                // Ensure ISR counter is clear following a write
 }
 
 void pio_i2c_stop(PIO pio, uint sm) {
@@ -80,11 +81,12 @@ void pio_i2c_stop(PIO pio, uint sm) {
 };
 
 void pio_i2c_repstart(PIO pio, uint sm) {
-    pio_i2c_put_or_err(pio, sm, 3u << PIO_I2C_ICOUNT_LSB);
+    pio_i2c_put_or_err(pio, sm, 4u << PIO_I2C_ICOUNT_LSB);
     pio_i2c_put_or_err(pio, sm, set_scl_sda_program_instructions[I2C_SC0_SD1]);
     pio_i2c_put_or_err(pio, sm, set_scl_sda_program_instructions[I2C_SC1_SD1]);
     pio_i2c_put_or_err(pio, sm, set_scl_sda_program_instructions[I2C_SC1_SD0]);
     pio_i2c_put_or_err(pio, sm, set_scl_sda_program_instructions[I2C_SC0_SD0]);
+    pio_i2c_put_or_err(pio, sm, pio_encode_mov(pio_isr, pio_null));
 }
 
 static void pio_i2c_wait_idle(PIO pio, uint sm) {


### PR DESCRIPTION
This avoids a spurious shift on a write followed by a read. See discussion on #617