### PR TITLE
Properly map IO and PAD register offsets for QSPI

### DIFF
--- a/bootloaders/uart/uart_binary.c
+++ b/bootloaders/uart/uart_binary.c
@@ -71,8 +71,8 @@ int main() {
     pico_led_init();
 
     // SD2 is UART0 TX, SD3 is UART0 RX (same as the ROM UART bootloader)
-    qspi_gpio_set_function(QSPI_GPIO_SD2, GPIO_FUNC_UART_AUX);
-    qspi_gpio_set_function(QSPI_GPIO_SD3, GPIO_FUNC_UART_AUX);
+    qspi_gpio_set_function(QSPI_GPIO_SD2, GPIO_FUNC1_UART_AUX);
+    qspi_gpio_set_function(QSPI_GPIO_SD3, GPIO_FUNC1_UART_AUX);
 
     uart_init(uart0, 1000000);
 

--- a/bootloaders/uart/uart_binary.c
+++ b/bootloaders/uart/uart_binary.c
@@ -14,7 +14,7 @@
 #endif
 
 // Initialize the GPIO for the LED
-static void pico_led_init(void) {
+void pico_led_init(void) {
 #ifdef PICO_DEFAULT_LED_PIN
     // A device like Pico that uses a GPIO for the LED will define PICO_DEFAULT_LED_PIN
     // so we can use normal GPIO functionality to turn the led on and off
@@ -24,7 +24,7 @@ static void pico_led_init(void) {
 }
 
 // Turn the LED on or off
-static void pico_set_led(bool led_on) {
+void pico_set_led(bool led_on) {
 #if defined(PICO_DEFAULT_LED_PIN)
     // Just set the GPIO on or off
     gpio_put(PICO_DEFAULT_LED_PIN, led_on);
@@ -43,7 +43,7 @@ enum qspi_gpio {
 
 // curiously the IO and PAD register banks for the QSPI GPIOs are not in the same order
 // This look up table will map the PAD offset to the IO offset for the same pin
-static const uint QSPI_GPIO_PAD_TO_IO_OFFSET[] = {
+const uint QSPI_GPIO_PAD_TO_IO_OFFSET[] = {
     0, // SCLK
     2, // SD0
     3, // SD1
@@ -53,7 +53,7 @@ static const uint QSPI_GPIO_PAD_TO_IO_OFFSET[] = {
 };
 
 // Set function for QSPI GPIO pin
-static void qspi_gpio_set_function(enum qspi_gpio gpio, gpio_function_t fn) {
+void qspi_gpio_set_function(enum qspi_gpio gpio, gpio_function_t fn) {
     // Set input enable on, output disable off
     hw_write_masked(&pads_qspi_hw->io[gpio],
                    PADS_QSPI_GPIO_QSPI_SD2_IE_BITS,


### PR DESCRIPTION
In the UART bootloader example the QSPI pins are used for normal IO and a `qspi_gpio_set_function()` function sets the pins' IO and PAD registers for use. This function didn't take into account that the IO and PAD register banks for the QSPI IOs are not in the same order. This PR corrects this by adding a lookup table to map between the two and takes an enum as the gpio parameter to signal to the caller the expected order for the function call.

It is worth noting that this example did happen to work for UART TX only due to happenstance. It configured offsets 3 and 4 (which were correct offsets for the PAD bank for SD2 and SD3), but these offsets map to SD1 and SD2 in the IO bank. This results in SD2 getting fully configured which provides UART0 TX, UART0 RX is left mis-configured and non-functional (only the PAD is configured), and SD1 gets its IO register erroneously configured. This example never made use of RX which is likely why this got missed since TX worked.

Even though this example happens to work, it's wroth correcting this function for posterity. Since the pico-sdk doesn't have functions for configuring the QSPI IOs, I found this example and assumed I could safely borrow this function, but the fact that it is incorrect lead to me burning several hours before I figured out what was going on. It's also likely worth getting the pin config for QSPI into the pico-sdk itself as a first class citizen, but for now it's worth fixing this example.

Also, if anyone has info on why the QSPI PAD and IO register offsets don't match, I'd love to know just out of curiosity. It's also curious that the QSPI IO bank has entries for the USB pins (DP and DM) at the start, but they don't have corresponding entries in PAD. You'd think those would have been put at the end of the bank. This is a non-issue code wise as the DP/DM are hard coded in the QSPI IO register map struct, and the `gpio[]` array for the actual QSPI pins does start at the base of the QSPI pins. It's all just odd...

Unrelated, this PR also adds `static` to local functions used in the UART example as a best practice.