### PR TITLE
Add support for pico 2 w

### DIFF
--- a/picoboard/button/CMakeLists.txt
+++ b/picoboard/button/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(picoboard_button
         )
 
 # pull in common dependencies
-target_link_libraries(picoboard_button pico_stdlib)
+target_link_libraries(picoboard_button pico_stdlib pico_status_led)
 
 # create map/bin/hex file etc.
 pico_add_extra_outputs(picoboard_button)


### PR DESCRIPTION
Refactored code to use pico_status_led instead of the old way ( according to [this issue](https://github.com/raspberrypi/pico-examples/issues/695#issuecomment-3189236040) )