### PR TITLE
chore: Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pio linguist-language=Assembly


### PR DESCRIPTION
With this Github will have proper syntax highlighting for `.pio` asm files