### PR TITLE
Skip uart bootloader when no mbedtls

### DIFF
--- a/bootloaders/CMakeLists.txt
+++ b/bootloaders/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_subdirectory_exclude_platforms(uart host rp2040)
-
 if (TARGET pico_mbedtls)
+    # note uart bootloader doesn't use Mbed TLS, but it requires picotool with Mbed TLS, so the above check is a good proxy
+    add_subdirectory_exclude_platforms(uart host rp2040)
     add_subdirectory_exclude_platforms(encrypted host rp2040 rp2350-riscv)
 else()
     # Assume picotool has no signing support, if no pico_mbedtls available
-    message("Skipping encrypted bootloader example as pico_mbedtls unavailable")
+    message("Skipping uart bootloader and encrypted bootloader examples as Mbed TLS is not available")
 endif ()


### PR DESCRIPTION
This requires the `picotool seal` command which is only available when compiled with mbedtls

Also improve message, in line with message in pico_w/wifi/CMakeLists.txt