### PR TITLE
Add .md to README and clarify what example does

### DIFF
--- a/pico_w/wifi/mqtt/README.md
+++ b/pico_w/wifi/mqtt/README.md
@@ -34,8 +34,8 @@ When building the code set the host name of the MQTT server, e.g.
 export MQTT_SERVER=myhost
 cmake ..
 ```
-
-The example should publish its core temperature to the /temperature topic. You can subscribe to this topic from another machine.
+The example checks its core temperature every ten seconds and if it has changed, publishes it to the
+/temperature topic. You can subscribe to this topic from another machine.
 
 ```
 mosquitto_sub -h $MQTT_SERVER -t '/temperature'
@@ -47,6 +47,11 @@ You can turn the led on and off by publishing messages.
 mosquitto_pub -h $MQTT_SERVER -t '/led' -m on
 mosquitto_pub -h $MQTT_SERVER -t '/led' -m off
 ```
+You can check the current the state of the led by subscribing to the /led/state topic on another machine.
+```
+mosquitto_sub -h $MQTT_SERVER -t '/led_state'
+```
+
 
 # Security
 

--- a/pico_w/wifi/mqtt/mqtt_client.c
+++ b/pico_w/wifi/mqtt/mqtt_client.c
@@ -243,6 +243,8 @@ static void mqtt_connection_cb(mqtt_client_t *client, void *arg, mqtt_connection
         if (!state->connect_done) {
             panic("Failed to connect to mqtt server");
         }
+        // note that the main() loop will soon terminate because mqtt_client_is_connected()
+        // will return false.  
     }
     else {
         panic("Unexpected status");
@@ -368,7 +370,13 @@ int main(void) {
         panic("dns request failed");
     }
 
+    // We are not in a callback but we can get away with calling mqtt_client_is_connected()
+    // because it's a read-only operation
     while (!state.connect_done || mqtt_client_is_connected(state.mqtt_client_inst)) {
+        // As supplied the example configures cyw43_arch for thread_safe_background operation
+        // by linking `ico_cyw43_arch_lwip_threadsafe_background` in CMakeLists.txt, so the 
+        // following two lines are unnecessary (but do no harm). However you will need them 
+        // if you reconfigure the build to use cyw43_arch in polling mode.
         cyw43_arch_poll();
         cyw43_arch_wait_for_work_until(make_timeout_time_ms(10000));
     }

--- a/pico_w/wifi/mqtt/mqtt_client.c
+++ b/pico_w/wifi/mqtt/mqtt_client.c
@@ -259,8 +259,10 @@ static void start_client(MQTT_CLIENT_DATA_T *state) {
     const int port = MQTT_PORT;
     INFO_printf("Warning: Not using TLS\n");
 #endif
-
+    // mqtt_client_new() has LWIP_ASSERT_CORE_LOCKED(), so we should protect this call
+    cyw43_arch_lwip_begin();
     state->mqtt_client_inst = mqtt_client_new();
+    cyw43_arch_lwip_end();
     if (!state->mqtt_client_inst) {
         panic("MQTT client instance creation error");
     }

--- a/pico_w/wifi/mqtt/mqtt_client.c
+++ b/pico_w/wifi/mqtt/mqtt_client.c
@@ -375,12 +375,18 @@ int main(void) {
     // We are not in a callback but we can get away with calling mqtt_client_is_connected()
     // because it's a read-only operation
     while (!state.connect_done || mqtt_client_is_connected(state.mqtt_client_inst)) {
-        // As supplied the example configures cyw43_arch for thread_safe_background operation
-        // by linking `pico_cyw43_arch_lwip_threadsafe_background` in CMakeLists.txt, so the 
-        // following two lines are unnecessary (but do no harm). However you will need them 
-        // if you reconfigure the build to use cyw43_arch in polling mode.
+
+    #ifdef PICO_CYW43_ARCH_POLL 
+        // if you use cyw43_arch in lwip_poll mode then you must periodically call
+        // cyw43_arch_poll() from your main loop (see SDK network API documentaion)
         cyw43_arch_poll();
         cyw43_arch_wait_for_work_until(make_timeout_time_ms(10000));
+    #else
+        // as supplied the example configures cyw43_arch for thread_safe_background
+        // operation (see CMakeLists.txt) so there's no need to poll
+        sleep_ms(10000);
+    #endif
+
     }
 
     INFO_printf("mqtt client exiting\n");

--- a/pico_w/wifi/mqtt/mqtt_client.c
+++ b/pico_w/wifi/mqtt/mqtt_client.c
@@ -374,7 +374,7 @@ int main(void) {
     // because it's a read-only operation
     while (!state.connect_done || mqtt_client_is_connected(state.mqtt_client_inst)) {
         // As supplied the example configures cyw43_arch for thread_safe_background operation
-        // by linking `ico_cyw43_arch_lwip_threadsafe_background` in CMakeLists.txt, so the 
+        // by linking `pico_cyw43_arch_lwip_threadsafe_background` in CMakeLists.txt, so the 
         // following two lines are unnecessary (but do no harm). However you will need them 
         // if you reconfigure the build to use cyw43_arch in polling mode.
         cyw43_arch_poll();


### PR DESCRIPTION
1. For pico_w/wifi/mqtt, rename README to README.md to improve how the content renders in an IDE or when browsing the online repository.
2. Clarify that the example doesn't re-publish the temperature reading if it hasn't changed; so that users can understand why the updates can appear sporadic.
3. Document how the led status can be checked by subscribing to /led/status