### PR TITLE
Deinit everything when restarting bt standalone temp sensor

### DIFF
--- a/pico_w/bt/standalone/server/server.c
+++ b/pico_w/bt/standalone/server/server.c
@@ -190,6 +190,11 @@ restart:
         async_context_wait_for_work_until(cyw43_arch_async_context(), at_the_end_of_time);
     }
 
+    att_server_deinit();
+
+    sm_deinit();
+    l2cap_deinit();
+
     cyw43_arch_deinit();
 
     printf("Press the \"S\" key to Start bluetooth\n");


### PR DESCRIPTION
Without this, I get an error when attempting to reconnect after a restart by pressing the S key:
```
Connecting to device with addr DE:AB:01:06:C1:6F.
SERVICE_QUERY_RESULT, ATT Error 0x7f.
Disconnected DE:AB:01:06:C1:6F
Connecting to device with addr DE:AB:01:06:C1:6F.
SERVICE_QUERY_RESULT, ATT Error 0x7f.
Disconnected DE:AB:01:06:C1:6F
...
```

With this fix everything works correctly when starting & stopping using the S key

I'm not sure if everything needs to be deinit'ed, but it is probably safest to deinit all three of these as they are init'ed above