### PR TITLE
http_client free pbuf in callbacks

### DIFF
--- a/pico_w/wifi/http_client/example_http_client_util.c
+++ b/pico_w/wifi/http_client/example_http_client_util.c
@@ -43,6 +43,7 @@ err_t http_client_header_print_fn(__unused httpc_state_t *connection, __unused v
         char c = (char)pbuf_get_at(hdr, offset++);
         HTTP_INFOC(c);
     }
+    pbuf_free(hdr);
     return ERR_OK;
 }
 
@@ -54,6 +55,7 @@ err_t http_client_receive_print_fn(__unused void *arg, __unused struct altcp_pcb
         char c = (char)pbuf_get_at(p, offset++);
         HTTP_INFOC(c);
     }
+    pbuf_free(p);
     return ERR_OK;
 }
 
@@ -64,6 +66,7 @@ static err_t internal_header_fn(httpc_state_t *connection, void *arg, struct pbu
     if (req->headers_fn) {
         return req->headers_fn(connection, req->callback_arg, hdr, hdr_len, content_len);
     }
+    pbuf_free(hdr);
     return ERR_OK;
 }
 


### PR DESCRIPTION
Free pbufs after they were used in multiple callbacks:
`http_client_header_print_fn` and `http_client_receive_print_fn` are example callbacks, that print the received data. The buffers should be freed afterwards, as they are not further used,

`internal_header_fn` is the internal function, that later calls a user callback. Only free the pbuf if no user callback is called. When a user callback is called, the freeing has to take place in there.

If the buffers are not freed, the MCU will eventually run out of RAM (in my application where I found the issue this occurred already after about twelve requests)