### PR TITLE
feat(devcontainer): Add DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    git \
+    cmake \
+    ninja-build \
+    build-essential \
+    gcc-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,5 @@
+# Pico Examples DevContainer
+
+This [DevContainer](https://containers.dev) a fully configured environment for building and flashing Raspberry Pi Pico projects using the Pico SDK and ARM toolchain.
+It can be used to work with samples or start developing your own Pico Firmware.
+Once it loads, you can proceed with using cmake as described in official [Pico SDK repository](https://github.com/raspberrypi/pico-sdk).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Pico DevContainer",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": [],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds basic [DevContainer](https://containers.dev) which allows to build `.uf2` files of samples and any other basic project based on Pico SDK.

I had some issues with configuring and installing all dependencies on my distro, working in devcontainer helped to get started.
I thought it might be helpful for others.

If this PR gets accepted, next step would be to update "Quick-start your own project" section in official SDK README to mention this alternative way. 