### PR TITLE
Add missing calls to disable STA/AP mode

### DIFF
--- a/bluetooth/ble_wifi_provisioner/example.c
+++ b/bluetooth/ble_wifi_provisioner/example.c
@@ -78,6 +78,9 @@ int main(void) {
         cyw43_arch_wait_for_work_until(at_the_end_of_time);
     }
 
+    // Switch off wifi nicely
+    cyw43_arch_disable_sta_mode();
+
     printf("Rebooting example...\n");
     watchdog_enable(500, true);
     sleep_ms(1000);

--- a/bluetooth/btstack_examples/main.c
+++ b/bluetooth/btstack_examples/main.c
@@ -77,6 +77,9 @@ int main() {
 
     btstack_run_loop_execute(); // run until btstack_run_loop_trigger_exit is called
 
+#if defined(WIFI_SSID) && defined(WIFI_PASSWORD)
+    cyw43_arch_disable_sta_mode();
+#endif
     cyw43_arch_deinit();
     return 0;
 }

--- a/pico_w/wifi/access_point/picow_access_point.c
+++ b/pico_w/wifi/access_point/picow_access_point.c
@@ -352,6 +352,7 @@ int main() {
     tcp_server_close(state);
     dns_server_deinit(&dns_server);
     dhcp_server_deinit(&dhcp_server);
+    cyw43_arch_disable_ap_mode();
     cyw43_arch_deinit();
     printf("Test complete\n");
     return 0;

--- a/pico_w/wifi/freertos/http_client/picow_freertos_http_client.c
+++ b/pico_w/wifi/freertos/http_client/picow_freertos_http_client.c
@@ -75,6 +75,7 @@ void main_task(__unused void *params) {
         panic("test failed");
     }
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     panic("Test passed");
 }

--- a/pico_w/wifi/freertos/httpd/pico_freertos_httpd.c
+++ b/pico_w/wifi/freertos/httpd/pico_freertos_httpd.c
@@ -172,6 +172,7 @@ void main_task(__unused void *params) {
     mdns_resp_remove_netif(&cyw43_state.netif[CYW43_ITF_STA]);
 #endif
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
 }
 

--- a/pico_w/wifi/freertos/iperf/picow_freertos_iperf.c
+++ b/pico_w/wifi/freertos/iperf/picow_freertos_iperf.c
@@ -89,6 +89,7 @@ void main_task(__unused void *params) {
         vTaskDelay(10000);
     }
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
 }
 

--- a/pico_w/wifi/freertos/ntp_client_socket/picow_freertos_ntp_client_socket.c
+++ b/pico_w/wifi/freertos/ntp_client_socket/picow_freertos_ntp_client_socket.c
@@ -144,6 +144,7 @@ void main_task(__unused void *params) {
         vTaskDelay(ntpEST_TIME);
     }
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
 }
 

--- a/pico_w/wifi/freertos/ping/picow_freertos_ping.c
+++ b/pico_w/wifi/freertos/ping/picow_freertos_ping.c
@@ -45,6 +45,7 @@ void main_task(__unused void *params) {
         vTaskDelay(100);
     }
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
 }
 

--- a/pico_w/wifi/http_client/picow_http_client.c
+++ b/pico_w/wifi/http_client/picow_http_client.c
@@ -51,6 +51,7 @@ int main() {
     if (result != 0) {
         panic("test failed");
     }
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     printf("Test passed\n");
     sleep_ms(100);

--- a/pico_w/wifi/http_client/picow_http_verify.c
+++ b/pico_w/wifi/http_client/picow_http_verify.c
@@ -90,6 +90,7 @@ int main() {
     if (pass != 0 || fail == 0) {
         panic("test failed");
     }
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     printf("Test passed\n");
     sleep_ms(100);

--- a/pico_w/wifi/httpd/pico_httpd.c
+++ b/pico_w/wifi/httpd/pico_httpd.c
@@ -240,5 +240,6 @@ int main() {
 #if LWIP_MDNS_RESPONDER
     mdns_resp_remove_netif(&cyw43_state.netif[CYW43_ITF_STA]);
 #endif
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
 }

--- a/pico_w/wifi/iperf/picow_iperf.c
+++ b/pico_w/wifi/iperf/picow_iperf.c
@@ -112,6 +112,7 @@ int main() {
     }
     cyw43_arch_disable_sta_mode();
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     printf("Test complete\n");
     return 0;

--- a/pico_w/wifi/mqtt/mqtt_client.c
+++ b/pico_w/wifi/mqtt/mqtt_client.c
@@ -392,5 +392,7 @@ int main(void) {
     }
 
     INFO_printf("mqtt client exiting\n");
+    cyw43_arch_disable_sta_mode();
+    cyw43_arch_deinit();
     return 0;
 }

--- a/pico_w/wifi/ntp_client/picow_ntp_client.c
+++ b/pico_w/wifi/ntp_client/picow_ntp_client.c
@@ -176,6 +176,7 @@ int main() {
         return 1;
     }
     run_ntp_test();
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
    return 0;
 }

--- a/pico_w/wifi/ota_update/picow_ota_update.c
+++ b/pico_w/wifi/ota_update/picow_ota_update.c
@@ -356,6 +356,7 @@ int main() {
         sleep_ms(250);
     }
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     ret = rom_reboot(REBOOT2_FLAG_REBOOT_TYPE_FLASH_UPDATE, 1000, state->flash_update, 0);
     printf("Done - rebooting for a flash update boot %d\n", ret);

--- a/pico_w/wifi/tcp_client/picow_tcp_client.c
+++ b/pico_w/wifi/tcp_client/picow_tcp_client.c
@@ -251,6 +251,7 @@ int main() {
         printf("Connected.\n");
     }
     run_tcp_client_test();
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     return 0;
 }

--- a/pico_w/wifi/tcp_server/picow_tcp_server.c
+++ b/pico_w/wifi/tcp_server/picow_tcp_server.c
@@ -263,6 +263,7 @@ int main() {
         printf("Connected.\n");
     }
     run_tcp_server_test();
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     return 0;
 }

--- a/pico_w/wifi/tls_client/picow_tls_client.c
+++ b/pico_w/wifi/tls_client/picow_tls_client.c
@@ -38,6 +38,7 @@ int main() {
     /* sleep a bit to let usb stdio write out any buffer to host */
     sleep_ms(100);
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     printf("All done\n");
     return pass ? 0 : 1;

--- a/pico_w/wifi/tls_client/tls_verify.c
+++ b/pico_w/wifi/tls_client/tls_verify.c
@@ -96,6 +96,7 @@ int main() {
     /* sleep a bit to let usb stdio write out any buffer to host */
     sleep_ms(100);
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     printf("All done\n");
     return (pass1 && pass2) ? 0 : 1;

--- a/pico_w/wifi/udp_beacon/picow_udp_beacon.c
+++ b/pico_w/wifi/udp_beacon/picow_udp_beacon.c
@@ -74,6 +74,7 @@ int main() {
         printf("Connected.\n");
     }
     run_udp_beacon();
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     return 0;
 }

--- a/pico_w/wifi/wifi_scan/picow_wifi_scan.c
+++ b/pico_w/wifi/wifi_scan/picow_wifi_scan.c
@@ -79,6 +79,7 @@ int main() {
 #endif
     }
 
+    cyw43_arch_disable_sta_mode();
     cyw43_arch_deinit();
     return 0;
 }


### PR DESCRIPTION
Some routers seem to get upset if you don't close disconnect gracefully.