### PR TITLE
Use new pio functions

### DIFF
--- a/pio/spi/spi.pio
+++ b/pio/spi/spi.pio
@@ -65,7 +65,7 @@ static inline void pio_spi_init(PIO pio, uint sm, uint prog_offs, uint n_bits,
     // and this is a cheesy way to get CPOL=1
     gpio_set_outover(pin_sck, cpol ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
     // SPI is synchronous, so bypass input synchroniser to reduce input delay.
-    hw_set_bits(&pio->input_sync_bypass, (pin_miso >= 32) ? (1u << (pin_miso - 16)) : (1u << pin_miso));
+    pio_set_input_sync_bypass_with_mask64(pio, 1ull << pin_miso, 1ull << pin_miso);
 
     pio_sm_init(pio, sm, prog_offs, &c);
     pio_sm_set_enabled(pio, sm, true);
@@ -157,7 +157,7 @@ static inline void pio_spi_cs_init(PIO pio, uint sm, uint prog_offs, uint n_bits
     pio_gpio_init(pio, pin_sck);
     pio_gpio_init(pio, pin_sck + 1);
     gpio_set_outover(pin_sck, cpol ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL);
-    hw_set_bits(&pio->input_sync_bypass, (pin_miso >= 32) ? (1u << (pin_miso - 16)) : (1u << pin_miso));
+    pio_set_input_sync_bypass_with_mask64(pio, 1ull << pin_miso, 1ull << pin_miso);
 
     uint entry_point = prog_offs + (cpha ? spi_cpha1_cs_offset_entry_point : spi_cpha0_cs_offset_entry_point);
     pio_sm_init(pio, sm, entry_point, &c);

--- a/pio/spi/spi_loopback.c
+++ b/pio/spi/spi_loopback.c
@@ -86,5 +86,5 @@ int main() {
         }
     }
     printf("Example %s\n", match_count == spi_example_runs ? "PASSED" : "FAILED");
-    assert(match_count == 4);
+    assert(match_count == spi_example_runs);
 }

--- a/pio/spi/spi_loopback.c
+++ b/pio/spi/spi_loopback.c
@@ -21,6 +21,8 @@
 
 #define BUF_SIZE 20
 
+static uint32_t match_count;
+
 void test(const pio_spi_inst_t *spi) {
     static uint8_t txbuf[BUF_SIZE];
     static uint8_t rxbuf[BUF_SIZE];
@@ -40,17 +42,23 @@ void test(const pio_spi_inst_t *spi) {
         printf(" %02x", (int) rxbuf[i]);
         mismatch = mismatch || rxbuf[i] != txbuf[i];
     }
-    if (mismatch)
+    if (mismatch) {
         printf("\nNope\n");
-    else
+    } else {
         printf("\nOK\n");
+        match_count++;
+    }
 }
 
 int main() {
     stdio_init_all();
-
+    printf("spi_loopback start\n");
     pio_spi_inst_t spi[2];
+#if 1
+    float clkdiv = 1; // as fast as possible!
+#else
     float clkdiv = 31.25f;  // 1 MHz @ 125 clk_sys
+#endif
 
     // pio_claim_free_sm_and_add_program_for_gpio_range finds a free pio and state machine for a program and sets the gpio base correctly
     const uint pin_base = MIN(PIN_SCK, MIN(PIN_MOSI, PIN_MISO));
@@ -75,4 +83,6 @@ int main() {
             sleep_ms(10);
         }
     }
+    printf("Example %s\n", match_count == 4 ? "passed" : "failed");
+    assert(match_count == 4);
 }

--- a/pio/spi/spi_loopback.c
+++ b/pio/spi/spi_loopback.c
@@ -66,8 +66,10 @@ int main() {
     hard_assert(pio_claim_free_sm_and_add_program_for_gpio_range(&spi_cpha0_program, &spi[0].pio, &spi[0].sm, &spi[0].offset, pin_base, pin_count, true));
     hard_assert(pio_claim_free_sm_and_add_program_for_gpio_range(&spi_cpha1_program, &spi[1].pio, &spi[1].sm, &spi[1].offset, pin_base, pin_count, true));
 
+    int spi_example_runs = 0;
     for (int cpha = 0; cpha <= 1; ++cpha) {
         for (int cpol = 0; cpol <= 1; ++cpol) {
+            spi_example_runs++;
             printf("CPHA = %d, CPOL = %d\n", cpha, cpol);
             pio_spi_init(spi[cpha].pio, spi[cpha].sm,
                          spi[cpha].offset,
@@ -83,6 +85,6 @@ int main() {
             sleep_ms(10);
         }
     }
-    printf("Example %s\n", match_count == 4 ? "passed" : "failed");
+    printf("Example %s\n", match_count == spi_example_runs ? "PASSED" : "FAILED");
     assert(match_count == 4);
 }

--- a/pio/spi/spi_loopback.c
+++ b/pio/spi/spi_loopback.c
@@ -21,7 +21,8 @@
 
 #define BUF_SIZE 20
 
-static uint32_t match_count;
+static int spi_example_passes;
+static int spi_example_runs;
 
 void test(const pio_spi_inst_t *spi) {
     static uint8_t txbuf[BUF_SIZE];
@@ -46,7 +47,7 @@ void test(const pio_spi_inst_t *spi) {
         printf("\nNope\n");
     } else {
         printf("\nOK\n");
-        match_count++;
+        spi_example_passes++;
     }
 }
 
@@ -66,7 +67,6 @@ int main() {
     hard_assert(pio_claim_free_sm_and_add_program_for_gpio_range(&spi_cpha0_program, &spi[0].pio, &spi[0].sm, &spi[0].offset, pin_base, pin_count, true));
     hard_assert(pio_claim_free_sm_and_add_program_for_gpio_range(&spi_cpha1_program, &spi[1].pio, &spi[1].sm, &spi[1].offset, pin_base, pin_count, true));
 
-    int spi_example_runs = 0;
     for (int cpha = 0; cpha <= 1; ++cpha) {
         for (int cpol = 0; cpol <= 1; ++cpol) {
             spi_example_runs++;
@@ -85,6 +85,6 @@ int main() {
             sleep_ms(10);
         }
     }
-    printf("Example %s\n", match_count == spi_example_runs ? "PASSED" : "FAILED");
-    assert(match_count == spi_example_runs);
+    printf("Example %s\n", spi_example_passes == spi_example_runs ? "PASSED" : "FAILED");
+    assert(spi_example_passes == spi_example_runs);
 }


### PR DESCRIPTION
We twiddle input_sync_bypass directly in the pio spi example. Use the new pio_set_input_sync_bypass_with_mask64 instead.

Run the loopback example at full speed and improve it so it's more obvious when the example doesn't work.