### PR TITLE
Access point fix to DNS and DHCP server

### DIFF
--- a/pico_w/wifi/access_point/dhcpserver/dhcpserver.c
+++ b/pico_w/wifi/access_point/dhcpserver/dhcpserver.c
@@ -270,10 +270,27 @@ static void dhcp_server_process(void *arg, struct udp_pcb *upcb, struct pbuf *p,
             }
             d->lease[yi].expiry = (cyw43_hal_ticks_ms() + DEFAULT_LEASE_TIME_S * 1000) >> 16;
             dhcp_msg.yiaddr[3] = DHCPS_BASE_IP + yi;
+
+            // Read the client's host name (option 12, RFC 2132) from the
+            // *incoming* options BEFORE opt_write_* below reuses this buffer to
+            // build the reply. It is optional and client-controlled, so it can
+            // be absent (some phones omit it or send a randomised name).
+            char hostname[32] = "";
+            uint8_t *hn = opt_find(opt, DHCP_OPT_HOST_NAME);
+            if (hn != NULL) {
+                uint8_t hn_len = hn[1];
+                if (hn_len > sizeof(hostname) - 1) {
+                    hn_len = sizeof(hostname) - 1;
+                }
+                memcpy(hostname, hn + 2, hn_len);
+                hostname[hn_len] = '\0';
+            }
+
             opt_write_u8(&opt, DHCP_OPT_MSG_TYPE, DHCPACK);
-            printf("DHCPS: client connected: MAC=%02x:%02x:%02x:%02x:%02x:%02x IP=%u.%u.%u.%u\n",
+            printf("DHCPS: client connected: MAC=%02x:%02x:%02x:%02x:%02x:%02x IP=%u.%u.%u.%u host=\"%s\"\n",
                 dhcp_msg.chaddr[0], dhcp_msg.chaddr[1], dhcp_msg.chaddr[2], dhcp_msg.chaddr[3], dhcp_msg.chaddr[4], dhcp_msg.chaddr[5],
-                dhcp_msg.yiaddr[0], dhcp_msg.yiaddr[1], dhcp_msg.yiaddr[2], dhcp_msg.yiaddr[3]);
+                dhcp_msg.yiaddr[0], dhcp_msg.yiaddr[1], dhcp_msg.yiaddr[2], dhcp_msg.yiaddr[3],
+                hostname);
             break;
         }
 
@@ -294,7 +311,7 @@ ignore_request:
     pbuf_free(p);
 }
 
-void dhcp_server_init(dhcp_server_t *d, ip_addr_t *ip, ip_addr_t *nm) {
+void dhcp_server_init(dhcp_server_t *d, struct netif *nif, ip_addr_t *ip, ip_addr_t *nm) {
     ip_addr_copy(d->ip, *ip);
     ip_addr_copy(d->nm, *nm);
     memset(d->lease, 0, sizeof(d->lease));
@@ -302,6 +319,13 @@ void dhcp_server_init(dhcp_server_t *d, ip_addr_t *ip, ip_addr_t *nm) {
         return;
     }
     dhcp_socket_bind(&d->udp, PORT_DHCP_SERVER);
+    // Restrict the server to a single interface (the AP). Without this the PCB
+    // is bound to the port on all netifs, so once a second netif exists (e.g. an
+    // active STA connection) the server could receive and answer DHCP requests
+    // arriving on it. udp_bind_netif guarantees rx and tx stay on this netif.
+    if (nif != NULL) {
+        udp_bind_netif(d->udp, nif);
+    }
 }
 
 void dhcp_server_deinit(dhcp_server_t *d) {

--- a/pico_w/wifi/access_point/dhcpserver/dhcpserver.h
+++ b/pico_w/wifi/access_point/dhcpserver/dhcpserver.h
@@ -43,7 +43,7 @@ typedef struct _dhcp_server_t {
     struct udp_pcb *udp;
 } dhcp_server_t;
 
-void dhcp_server_init(dhcp_server_t *d, ip_addr_t *ip, ip_addr_t *nm);
+void dhcp_server_init(dhcp_server_t *d, struct netif *nif, ip_addr_t *ip, ip_addr_t *nm);
 void dhcp_server_deinit(dhcp_server_t *d);
 
 #endif // MICROPY_INCLUDED_LIB_NETUTILS_DHCPSERVER_H

--- a/pico_w/wifi/access_point/dnsserver/dnsserver.c
+++ b/pico_w/wifi/access_point/dnsserver/dnsserver.c
@@ -217,7 +217,7 @@ ignore_request:
     pbuf_free(p);
 }
 
-void dns_server_init(dns_server_t *d, ip_addr_t *ip) {
+void dns_server_init(dns_server_t *d, struct netif *nif, ip_addr_t *ip) {
     if (dns_socket_new_dgram(&d->udp, d, dns_server_process) != ERR_OK) {
         DEBUG_printf("dns server failed to start\n");
         return;
@@ -225,6 +225,13 @@ void dns_server_init(dns_server_t *d, ip_addr_t *ip) {
     if (dns_socket_bind(&d->udp, 0, PORT_DNS_SERVER) != ERR_OK) {
         DEBUG_printf("dns server failed to bind\n");
         return;
+    }
+    // Restrict the server to a single interface (the AP). The bind above uses
+    // IP_ADDR_ANY, so without this the PCB listens on every netif and would
+    // answer DNS queries arriving via an active STA connection too. This also
+    // pins replies to the same netif (udp_sendto here is not interface-bound).
+    if (nif != NULL) {
+        udp_bind_netif(d->udp, nif);
     }
     ip_addr_copy(d->ip, *ip);
     DEBUG_printf("dns server listening on port %d\n", PORT_DNS_SERVER);

--- a/pico_w/wifi/access_point/dnsserver/dnsserver.h
+++ b/pico_w/wifi/access_point/dnsserver/dnsserver.h
@@ -14,7 +14,7 @@ typedef struct dns_server_t_ {
      ip_addr_t ip;
 } dns_server_t;
 
-void dns_server_init(dns_server_t *d, ip_addr_t *ip);
+void dns_server_init(dns_server_t *d, struct netif *nif, ip_addr_t *ip);
 void dns_server_deinit(dns_server_t *d);
 
 #endif

--- a/pico_w/wifi/access_point/picow_access_point.c
+++ b/pico_w/wifi/access_point/picow_access_point.c
@@ -131,11 +131,11 @@ int main() {
 
     // Start the dhcp server
     dhcp_server_t dhcp_server;
-    dhcp_server_init(&dhcp_server, &gw, &mask);
+    dhcp_server_init(&dhcp_server, &cyw43_state.netif[CYW43_ITF_AP], &gw, &mask);
 
     // Start the dns server
     dns_server_t dns_server;
-    dns_server_init(&dns_server, &gw);
+    dns_server_init(&dns_server, &cyw43_state.netif[CYW43_ITF_AP], &gw);
 
     // setup http server
     wifi_connected_time = get_absolute_time();


### PR DESCRIPTION
Make sure the DHCP and DNS server only use the AP netif. Should stop them answer queries from other networks.
Also log the host in DHCP