### PR TITLE
Improve BT example run loop use

### DIFF
--- a/bluetooth/ble_doorbell/client.c
+++ b/bluetooth/ble_doorbell/client.c
@@ -299,8 +299,8 @@ int main() {
 #if 1
     btstack_run_loop_execute();
 #else
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // This example uses the `threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is possible to continue executing user code instead of calling bt_stack_run_loop_execute(). You must not
     // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
     // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {

--- a/bluetooth/ble_doorbell/client.c
+++ b/bluetooth/ble_doorbell/client.c
@@ -296,18 +296,14 @@ int main() {
     // turn on!
     hci_power_control(HCI_POWER_ON);
 
-    // btstack_run_loop_execute is only required when using the 'polling' method (e.g. using pico_cyw43_arch_poll library).
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code.
-
-#if 1 // this is only necessary when using polling (which we aren't, but we're showing it is still safe to call in this case)
+#if 1
     btstack_run_loop_execute();
 #else
-    // this core is free to do it's own stuff except when using 'polling' method (in which case you should use 
-    // btstacK_run_loop_ methods to add work to the run loop.
-
-    // this is a forever loop in place of where user code would go.
-    while(true) {      
+    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
+    // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
+    while(true) {
         sleep_ms(1000);
     }
 #endif

--- a/bluetooth/ble_doorbell/server.c
+++ b/bluetooth/ble_doorbell/server.c
@@ -176,8 +176,8 @@ int main() {
 #if 1
     btstack_run_loop_execute();
 #else
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // This example uses the `threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is possible to continue executing user code instead of calling bt_stack_run_loop_execute(). You must not
     // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
     // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {

--- a/bluetooth/ble_doorbell/server.c
+++ b/bluetooth/ble_doorbell/server.c
@@ -173,18 +173,14 @@ int main() {
     // turn on bluetooth!
     hci_power_control(HCI_POWER_ON);
     
-    // btstack_run_loop_execute is only required when using the 'polling' method (e.g. using pico_cyw43_arch_poll library).
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code.
-
-#if 0 // btstack_run_loop_execute() is not required, so lets not use it
+#if 1
     btstack_run_loop_execute();
 #else
-    // this core is free to do it's own stuff except when using 'polling' method (in which case you should use 
-    // btstacK_run_loop_ methods to add work to the run loop.
-    
-    // this is a forever loop in place of where user code would go.
-    while(true) {      
+    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
+    // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
+    while(true) {
         sleep_ms(1000);
     }
 #endif

--- a/bluetooth/ble_pointer/ble_pointer.c
+++ b/bluetooth/ble_pointer/ble_pointer.c
@@ -458,8 +458,8 @@ int main(void) {
 #if 1
     btstack_run_loop_execute();
 #else
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // This example uses the `threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is possible to continue executing user code instead of calling bt_stack_run_loop_execute(). You must not
     // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
     // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {

--- a/bluetooth/ble_pointer/ble_pointer.c
+++ b/bluetooth/ble_pointer/ble_pointer.c
@@ -455,17 +455,13 @@ int main(void) {
     // turn on!
     hci_power_control(HCI_POWER_ON);
 
-    // btstack_run_loop_execute is only required when using the 'polling' method (e.g. using pico_cyw43_arch_poll library).
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code.
-
-#if 1 // this is only necessary when using polling (which we aren't, but we're showing it is still safe to call in this case)
+#if 1
     btstack_run_loop_execute();
 #else
-    // this core is free to do it's own stuff except when using 'polling' method (in which case you should use
-    // btstacK_run_loop_ methods to add work to the run loop.
-
-    // this is a forever loop in place of where user code would go.
+    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
+    // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {
         sleep_ms(1000);
     }

--- a/bluetooth/ble_secure_temp_sensor/client.c
+++ b/bluetooth/ble_secure_temp_sensor/client.c
@@ -547,18 +547,14 @@ int main() {
     // turn on!
     hci_power_control(HCI_POWER_ON);
 
-    // btstack_run_loop_execute is only required when using the 'polling' method (e.g. using pico_cyw43_arch_poll library).
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code.
-
-#if 1 // this is only necessary when using polling (which we aren't, but we're showing it is still safe to call in this case)
+#if 1
     btstack_run_loop_execute();
 #else
-    // this core is free to do it's own stuff except when using 'polling' method (in which case you should use 
-    // btstacK_run_loop_ methods to add work to the run loop.
-
-    // this is a forever loop in place of where user code would go.
-    while(true) {      
+    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
+    // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
+    while(true) {
         sleep_ms(1000);
     }
 #endif

--- a/bluetooth/ble_secure_temp_sensor/client.c
+++ b/bluetooth/ble_secure_temp_sensor/client.c
@@ -550,8 +550,8 @@ int main() {
 #if 1
     btstack_run_loop_execute();
 #else
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // This example uses the `threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is possible to continue executing user code instead of calling bt_stack_run_loop_execute(). You must not
     // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
     // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {

--- a/bluetooth/ble_secure_temp_sensor/server.c
+++ b/bluetooth/ble_secure_temp_sensor/server.c
@@ -430,8 +430,8 @@ int main() {
 #if 1
     btstack_run_loop_execute();
 #else
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // This example uses the `threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is possible to continue executing user code instead of calling bt_stack_run_loop_execute(). You must not
     // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
     // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {

--- a/bluetooth/ble_secure_temp_sensor/server.c
+++ b/bluetooth/ble_secure_temp_sensor/server.c
@@ -427,18 +427,14 @@ int main() {
     // turn on bluetooth!
     hci_power_control(HCI_POWER_ON);
     
-    // btstack_run_loop_execute is only required when using the 'polling' method (e.g. using pico_cyw43_arch_poll library).
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code.
-
-#if 0 // btstack_run_loop_execute() is not required, so lets not use it
+#if 1
     btstack_run_loop_execute();
 #else
-    // this core is free to do it's own stuff except when using 'polling' method (in which case you should use 
-    // btstacK_run_loop_ methods to add work to the run loop.
-    
-    // this is a forever loop in place of where user code would go.
-    while(true) {      
+    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
+    // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
+    while(true) {
         sleep_ms(1000);
     }
 #endif

--- a/bluetooth/ble_temp_sensor/CMakeLists.txt
+++ b/bluetooth/ble_temp_sensor/CMakeLists.txt
@@ -44,3 +44,30 @@ target_compile_definitions(ble_temp_reader PRIVATE
 )
 pico_add_extra_outputs(ble_temp_reader)
 example_auto_set_url(ble_temp_reader)
+
+# Low Power Example that reads from the on board temperature sensor and sends notifications via BLE
+# Flashes slowly each second to show it's running
+# Goes to low power state after 2 readings
+add_executable(ble_temp_server_low_power
+    server.c
+    )
+target_link_libraries(ble_temp_server_low_power
+    pico_stdlib
+    pico_btstack_ble
+    pico_btstack_cyw43
+    pico_cyw43_arch_none
+    hardware_adc
+    pico_low_power
+    )
+target_include_directories(ble_temp_server_low_power PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR} # For our btstack config
+    ${CMAKE_CURRENT_LIST_DIR}/../config # for common btstack config
+    )
+target_compile_definitions(ble_temp_server_low_power PRIVATE
+    #WANT_HCI_DUMP=1
+    SERVER_LOW_POWER=1
+)
+pico_btstack_make_gatt_header(ble_temp_server_low_power PRIVATE "${CMAKE_CURRENT_LIST_DIR}/temp_sensor.gatt")
+
+pico_add_extra_outputs(ble_temp_server_low_power)
+example_auto_set_url(ble_temp_server_low_power)

--- a/bluetooth/ble_temp_sensor/client.c
+++ b/bluetooth/ble_temp_sensor/client.c
@@ -278,18 +278,14 @@ int main() {
     // turn on!
     hci_power_control(HCI_POWER_ON);
 
-    // btstack_run_loop_execute is only required when using the 'polling' method (e.g. using pico_cyw43_arch_poll library).
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code.
-
-#if 1 // this is only necessary when using polling (which we aren't, but we're showing it is still safe to call in this case)
+#if 1
     btstack_run_loop_execute();
 #else
-    // this core is free to do it's own stuff except when using 'polling' method (in which case you should use 
-    // btstacK_run_loop_ methods to add work to the run loop.
-
-    // this is a forever loop in place of where user code would go.
-    while(true) {      
+    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
+    // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
+    while(true) {
         sleep_ms(1000);
     }
 #endif

--- a/bluetooth/ble_temp_sensor/client.c
+++ b/bluetooth/ble_temp_sensor/client.c
@@ -281,8 +281,8 @@ int main() {
 #if 1
     btstack_run_loop_execute();
 #else
-    // This example uses the 'threadsafe background` method, where BT work is handled in a low priority IRQ, so it
-    // is fine to call bt_stack_run_loop_execute() but equally you can continue executing user code. You must not
+    // This example uses the `threadsafe background` method, where BT work is handled in a low priority IRQ, so it
+    // is possible to continue executing user code instead of calling bt_stack_run_loop_execute(). You must not
     // perform any BT work in user code (e.g calling `hci_power_control(HCI_POWER_OFF)`) - those operations must be
     // performed inside the run loop (e.g. using `btstack_run_loop_execute_on_main_thread`).
     while(true) {

--- a/bluetooth/ble_temp_sensor/server.c
+++ b/bluetooth/ble_temp_sensor/server.c
@@ -242,7 +242,7 @@ int main() {
 #if SERVER_LOW_POWER
     // Custom low power run loop, using low power sleep
     while (!exit_run_loop) {
-        // This will us the same timer as the bluetooth processing, so that will continue to work
+        // This will use the same timer as the bluetooth processing, so that will continue to work
         low_power_sleep_for_ms(1000, NULL, false);
     }
 #else
@@ -255,8 +255,8 @@ int main() {
     printf("Going to low power state for %ds\n", POWER_DOWN_TIME_S);
     low_power_set_pins_low_leakage_exclude_mask(0);
 #if HAS_POWMAN_TIMER
-    low_power_pstate_for_ms(POWER_DOWN_TIME_MS, NULL, NULL);
-    while(true); // wait for reboot
+    int rc = low_power_pstate_for_ms(POWER_DOWN_TIME_MS, NULL, NULL);
+    printf("low_power_pstate_for_ms returned error %d\n", rc);
 #else
     low_power_dormant_for_ms(POWER_DOWN_TIME_MS, DORMANT_CLOCK_SOURCE_DEFAULT, NULL);
     watchdog_reboot(0, 0, 10);

--- a/bluetooth/ble_temp_sensor/server.c
+++ b/bluetooth/ble_temp_sensor/server.c
@@ -119,17 +119,24 @@ static void heartbeat_handler(struct btstack_timer_source *ts) {
     static uint32_t counter = 0;
     counter++;
 
-    // Update the temp every 10s
-    if (counter % 10 == 0) {
-        poll_temp();
-        if (le_notification_enabled) {
-            att_server_request_can_send_now_event(con_handle);
+    static int led_on = true;
+
+    if (hci_get_state() == HCI_STATE_OFF) {
+        // Blink the led every 10s
+        led_on = (counter % 10 == 0);
+    } else {
+        // Update the temp every 10s
+        if (counter % 10 == 0) {
+            poll_temp();
+            if (le_notification_enabled) {
+                att_server_request_can_send_now_event(con_handle);
+            }
         }
+
+        // Invert the led every 1s
+        led_on = !led_on;
     }
 
-    // Invert the led
-    static int led_on = true;
-    led_on = !led_on;
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
 
     // Restart timer
@@ -137,18 +144,35 @@ static void heartbeat_handler(struct btstack_timer_source *ts) {
     btstack_run_loop_add_timer(ts);
 }
 
-static volatile bool key_pressed;
+static void bt_start_stop_fn(__unused void * arg) {
+    if (hci_get_state() == HCI_STATE_OFF) {
+        hci_power_control(HCI_POWER_ON);
+        printf("Press the \"S\" key to Stop bluetooth\n");
+    } else {
+        hci_power_control(HCI_POWER_OFF);
+        printf("Press the \"S\" key to Start bluetooth\n");
+    }
+}
+static btstack_context_callback_registration_t bt_start_stop = { .callback = bt_start_stop_fn };
+
+static void bt_exit_fn(__unused void * arg) {
+    hci_power_control(HCI_POWER_OFF);
+    btstack_run_loop_trigger_exit();
+}
+static btstack_context_callback_registration_t bt_exit = { .callback = bt_exit_fn };
+
 void key_pressed_func(void *param) {
     int key = getchar_timeout_us(0); // get any pending key press but don't wait
     if (key == 's' || key == 'S') {
-        key_pressed = true;
+        btstack_run_loop_execute_on_main_thread(&bt_start_stop);
+    } else if (key == 'e' || key == 'E') {
+        btstack_run_loop_execute_on_main_thread(&bt_exit);
     }
 }
 
 int main() {
     stdio_init_all();
 
-restart:
     // initialize CYW43 driver architecture (will enable BT if/because CYW43_ENABLE_BLUETOOTH == 1)
     if (cyw43_arch_init()) {
         printf("failed to initialise cyw43_arch\n");
@@ -157,6 +181,7 @@ restart:
 
     // Get notified if the user presses a key
     printf("Press the \"S\" key to Stop bluetooth\n");
+    printf("Press the \"E\" key to Exit the program\n");
     stdio_set_chars_available_callback(key_pressed_func, NULL);
 
     // Initialise adc for the temp sensor
@@ -184,24 +209,11 @@ restart:
     // turn on bluetooth!
     hci_power_control(HCI_POWER_ON);
 
-    key_pressed = false;
-    while(!key_pressed) {
-        async_context_poll(cyw43_arch_async_context());
-        async_context_wait_for_work_until(cyw43_arch_async_context(), at_the_end_of_time);
-    }
-
-    att_server_deinit();
-
-    sm_deinit();
-    l2cap_deinit();
+    btstack_run_loop_execute();
 
     cyw43_arch_deinit();
 
-    printf("Press the \"S\" key to Start bluetooth\n");
-    key_pressed = false;
-    while(!key_pressed) {
-        sleep_ms(1000);
-    }
-    goto restart;
+    printf("Exiting\n");
+
     return 0;
 }

--- a/bluetooth/ble_temp_sensor/server.c
+++ b/bluetooth/ble_temp_sensor/server.c
@@ -23,7 +23,7 @@
 // Uses the watchdog to reboot, as there is no powman
 #include "hardware/watchdog.h"
 #endif
-#define POWER_UP_TIME_S 15
+#define POWER_UP_HEARTBEATS 15
 #define POWER_DOWN_TIME_S 60
 #define POWER_DOWN_TIME_MS (POWER_DOWN_TIME_S * 1000)
 
@@ -164,7 +164,7 @@ static void heartbeat_handler(struct btstack_timer_source *ts) {
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
 
 #if SERVER_LOW_POWER
-    if (counter >= POWER_UP_TIME_S) {
+    if (counter >= POWER_UP_HEARTBEATS) {
         // Exit to go to low power state
         btstack_run_loop_execute_on_main_thread(&bt_exit);
         return;

--- a/bluetooth/ble_temp_sensor/server.c
+++ b/bluetooth/ble_temp_sensor/server.c
@@ -178,7 +178,9 @@ static void heartbeat_handler(struct btstack_timer_source *ts) {
 
 #if !SERVER_LOW_POWER
 static void bt_start_stop_fn(__unused void * arg) {
-    if (hci_get_state() == HCI_STATE_OFF) {
+    static bool bt_start_stop_state = true;
+    bt_start_stop_state = !bt_start_stop_state;
+    if (bt_start_stop_state) {
         hci_power_control(HCI_POWER_ON);
         printf("Press the \"S\" key to Stop bluetooth\n");
     } else {
@@ -206,13 +208,6 @@ int main() {
         printf("failed to initialise cyw43_arch\n");
         return -1;
     }
-
-#if !SERVER_LOW_POWER
-    // Get notified if the user presses a key
-    printf("Press the \"S\" key to Stop bluetooth\n");
-    printf("Press the \"E\" key to Exit the program\n");
-    stdio_set_chars_available_callback(key_pressed_func, NULL);
-#endif
 
     // Initialise adc for the temp sensor
     adc_init();
@@ -246,6 +241,11 @@ int main() {
         low_power_sleep_for_ms(1000, NULL, false);
     }
 #else
+    // Get notified if the user presses a key
+    printf("Press the \"S\" key to Stop bluetooth\n");
+    printf("Press the \"E\" key to Exit the program\n");
+    stdio_set_chars_available_callback(key_pressed_func, NULL);
+
     btstack_run_loop_execute(); // run until btstack_run_loop_trigger_exit is called
 #endif
 

--- a/bluetooth/ble_temp_sensor/server.c
+++ b/bluetooth/ble_temp_sensor/server.c
@@ -17,6 +17,19 @@
 #define ADC_CHANNEL_TEMPSENSOR 4
 #define APP_AD_FLAGS 0x06
 
+#if SERVER_LOW_POWER
+#include "pico/low_power.h"
+#if !HAS_POWMAN_TIMER
+// Uses the watchdog to reboot, as there is no powman
+#include "hardware/watchdog.h"
+#endif
+#define POWER_UP_TIME_S 15
+#define POWER_DOWN_TIME_S 60
+#define POWER_DOWN_TIME_MS (POWER_DOWN_TIME_S * 1000)
+
+static bool exit_run_loop = false;
+#endif
+
 static uint8_t adv_data[] = {
     // Flags general discoverable
     0x02, BLUETOOTH_DATA_TYPE_FLAGS, APP_AD_FLAGS,
@@ -113,7 +126,18 @@ static void poll_temp(void) {
     float deg_c = 27 - (reading - 0.706) / 0.001721;
     current_temp = deg_c * 100;
     printf("Write temp %.2f degc\n", deg_c);
- }
+}
+
+static void bt_exit_fn(__unused void * arg) {
+    hci_power_control(HCI_POWER_OFF);
+#if SERVER_LOW_POWER
+    // Custom run loop exit variable
+    exit_run_loop = true;
+#else
+    btstack_run_loop_trigger_exit();
+#endif
+}
+static btstack_context_callback_registration_t bt_exit = { .callback = bt_exit_fn };
 
 static void heartbeat_handler(struct btstack_timer_source *ts) {
     static uint32_t counter = 0;
@@ -139,11 +163,20 @@ static void heartbeat_handler(struct btstack_timer_source *ts) {
 
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, led_on);
 
+#if SERVER_LOW_POWER
+    if (counter >= POWER_UP_TIME_S) {
+        // Exit to go to low power state
+        btstack_run_loop_execute_on_main_thread(&bt_exit);
+        return;
+    }
+#endif
+
     // Restart timer
     btstack_run_loop_set_timer(ts, HEARTBEAT_PERIOD_MS);
     btstack_run_loop_add_timer(ts);
 }
 
+#if !SERVER_LOW_POWER
 static void bt_start_stop_fn(__unused void * arg) {
     if (hci_get_state() == HCI_STATE_OFF) {
         hci_power_control(HCI_POWER_ON);
@@ -155,12 +188,6 @@ static void bt_start_stop_fn(__unused void * arg) {
 }
 static btstack_context_callback_registration_t bt_start_stop = { .callback = bt_start_stop_fn };
 
-static void bt_exit_fn(__unused void * arg) {
-    hci_power_control(HCI_POWER_OFF);
-    btstack_run_loop_trigger_exit();
-}
-static btstack_context_callback_registration_t bt_exit = { .callback = bt_exit_fn };
-
 void key_pressed_func(void *param) {
     int key = getchar_timeout_us(0); // get any pending key press but don't wait
     if (key == 's' || key == 'S') {
@@ -169,6 +196,7 @@ void key_pressed_func(void *param) {
         btstack_run_loop_execute_on_main_thread(&bt_exit);
     }
 }
+#endif
 
 int main() {
     stdio_init_all();
@@ -179,10 +207,12 @@ int main() {
         return -1;
     }
 
+#if !SERVER_LOW_POWER
     // Get notified if the user presses a key
     printf("Press the \"S\" key to Stop bluetooth\n");
     printf("Press the \"E\" key to Exit the program\n");
     stdio_set_chars_available_callback(key_pressed_func, NULL);
+#endif
 
     // Initialise adc for the temp sensor
     adc_init();
@@ -209,11 +239,32 @@ int main() {
     // turn on bluetooth!
     hci_power_control(HCI_POWER_ON);
 
-    btstack_run_loop_execute();
+#if SERVER_LOW_POWER
+    // Custom low power run loop, using low power sleep
+    while (!exit_run_loop) {
+        // This will us the same timer as the bluetooth processing, so that will continue to work
+        low_power_sleep_for_ms(1000, NULL, false);
+    }
+#else
+    btstack_run_loop_execute(); // run until btstack_run_loop_trigger_exit is called
+#endif
 
     cyw43_arch_deinit();
 
+#if SERVER_LOW_POWER
+    printf("Going to low power state for %ds\n", POWER_DOWN_TIME_S);
+    low_power_set_pins_low_leakage_exclude_mask(0);
+#if HAS_POWMAN_TIMER
+    low_power_pstate_for_ms(POWER_DOWN_TIME_MS, NULL, NULL);
+    while(true); // wait for reboot
+#else
+    low_power_dormant_for_ms(POWER_DOWN_TIME_MS, DORMANT_CLOCK_SOURCE_DEFAULT, NULL);
+    watchdog_reboot(0, 0, 10);
+    while (true); // wait for reboot
+#endif
+#else
     printf("Exiting\n");
+#endif
 
     return 0;
 }


### PR DESCRIPTION
This standardises the standalone BT examples to use `btstack_run_loop_execute` by default, with a brief explanation that you can also run user code instead, but must not perform any BT work in that code. These examples all use `threadsafe_background`, so I removed the references to polling. If we do want to support polling, that can be added with `PICO_CYW43_ARCH_POLL`, similar to the wifi examples.

`ble_temp_server` is modified to support staying in the run loop when starting/stopping, to avoid the need to call the `deinit` functions as those should not be used (see https://github.com/raspberrypi/pico-examples/pull/745#issuecomment-4679259208)

A new `ble_temp_server_low_power` example is also added, demonstrating a custom lower power run loop, and running for 15s on then powering down for 60s (pstate if available, otherwise dormant followed by watchdog reboot).