### PR TITLE
tinyusb examples fail to build with latest tinyusb

### DIFF
--- a/usb/CMakeLists.txt
+++ b/usb/CMakeLists.txt
@@ -11,6 +11,14 @@ set(TINYUSB_OPT_OS OPT_OS_PICO)
 # Same issue as above - this variable goes out of scope
 set(LINKERMAP_PY ${PICO_TINYUSB_PATH}/tools/linkermap/linkermap.py)
 
+if (NOT EXISTS ${LINKERMAP_PY})
+    # family_add_linkermap tries to run tinyusb/tools/linkermap/linkermap.py
+    # But this file only exists if you run python tools/get_deps.py
+    # So override the function to do nothing if the file does not exist
+    function(family_add_linkermap TARGET)
+    endfunction()
+endif()
+
 # List of freertos examples
 set(tinyusb_freertos_examples
     audio_4_channel_mic_freertos

--- a/usb/device/dev_hid_composite/tusb_config.h
+++ b/usb/device/dev_hid_composite/tusb_config.h
@@ -53,8 +53,9 @@
 #error CFG_TUSB_MCU must be defined
 #endif
 
+// Make sure CFG_TUSB_OS is defined properly
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS           OPT_OS_NONE
+#define CFG_TUSB_OS           OPT_OS_PICO
 #endif
 
 #ifndef CFG_TUSB_DEBUG

--- a/usb/device/dev_multi_cdc/tusb_config.h
+++ b/usb/device/dev_multi_cdc/tusb_config.h
@@ -35,6 +35,11 @@
 #define CFG_TUD_ENDPOINT0_SIZE  (64)
 #endif
 
+// Make sure CFG_TUSB_OS is defined properly
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS             OPT_OS_PICO
+#endif
+
 #ifdef __cplusplus
  }
 #endif

--- a/usb/host/host_cdc_msc_hid/tusb_config.h
+++ b/usb/host/host_cdc_msc_hid/tusb_config.h
@@ -39,8 +39,9 @@
 #error CFG_TUSB_MCU must be defined
 #endif
 
+// Make sure CFG_TUSB_OS is defined properly
 #ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS           OPT_OS_NONE
+#define CFG_TUSB_OS           OPT_OS_PICO
 #endif
 
 #ifndef CFG_TUSB_DEBUG


### PR DESCRIPTION
The tinyusb examples in the latest version of tinyusb 0.21.0 try and run tinyusb/tools/linkermap/linkermap.py which only exists if you have run tools/get_deps.py

Override family_add_linkermap to do nothing if this file does not exist - which allows the examples to build cleanly.