### PR TITLE
Fix onboard temperature ADC example for RP2350B

### DIFF
--- a/adc/onboard_temperature/onboard_temperature.c
+++ b/adc/onboard_temperature/onboard_temperature.c
@@ -44,7 +44,7 @@ int main() {
      *   is a global operation). */
     adc_init();
     adc_set_temp_sensor_enabled(true);
-    adc_select_input(4);
+    adc_select_input(ADC_TEMPERATURE_CHANNEL_NUM);
 
     while (true) {
         float temperature = read_onboard_temperature(TEMPERATURE_UNITS);


### PR DESCRIPTION
When doing some work on an RP2350B, which has 8 ADC channels, I noticed that this ADC example didn't work due to a hard coded ADC channel.

Use of the appropriate #define should ensure that this works as expected on all RP2x