### PR TITLE
Fix to workaround changes in family_ funcs for examples in latest TinyUSB

### DIFF
--- a/usb/CMakeLists.txt
+++ b/usb/CMakeLists.txt
@@ -1,15 +1,5 @@
-# family.cmake defines TINYUSB_OPT_OS and is included twice...
-# 1/ the first time by pico-sdk in src/rp2_common/tinyusb/CMakeLists.txt
-# 2/ before each tinyusb example via family_support.cmake
-# family.cmake has include_guard(GLOBAL) so the second include doesn't happen
-# But each example calls the cmake function family_configure_device_example
-# as the second include didn't happen TINYUSB_OPT_OS has gone out of scope
-# So make sure it's defined to avoid a redefinition with an invalid value
-# For freertos examples TINYUSB_OPT_OS is actually defined in FreeRTOSConfig.h
+# This is not set by default in latest TinyUSB
 set(TINYUSB_OPT_OS OPT_OS_PICO)
-
-# Same issue as above - this variable goes out of scope
-set(LINKERMAP_PY ${PICO_TINYUSB_PATH}/tools/linkermap/linkermap.py)
 
 # List of freertos examples
 set(tinyusb_freertos_examples
@@ -32,17 +22,14 @@ if (SHOULD_ADD)
             msc_file_explorer msc_file_explorer_freertos # need fatfs repo
         )
     endif()
-    if (NOT DEFINED FREERTOS_KERNEL_PATH)
+    if (NOT TARGET FreeRTOS-Kernel)
         # skip freertos examples
         list(APPEND tinyusb_example_ignore_list
             ${tinyusb_freertos_examples}
         )
     endif()
     list(FIND tinyusb_example_ignore_list ${DIR} skip_pos)
-    if (skip_pos GREATER_EQUAL 0)
-        set(SHOULD_ADD 0)
-    endif()
-    if (SHOULD_ADD)
+    if (skip_pos LESS 0)
         add_subdirectory(${DIR})
     endif()
 endif()

--- a/usb/CMakeLists.txt
+++ b/usb/CMakeLists.txt
@@ -11,30 +11,37 @@ set(tinyusb_freertos_examples
     msc_file_explorer_freertos
 )
 
+# this function is added in later TinyUSB but requires
+# tools/get_deps.py to have been runing withint TinyUSB
+#
+# it just prints out code sizes which isn't really needed
+# here, so just make it a no-op
+function(family_add_linkermap TARGET)
+endfunction()
+
 # This is used to filter the tinyusb examples
 # Ignore examples that don't build properly without extra code
 # Ignore freertos examples unless FREERTOS_KERNEL_PATH is defined
 function(family_add_subdirectory DIR)
-family_filter(SHOULD_ADD "${DIR}")
-if (SHOULD_ADD)
-    if (NOT IS_DIRECTORY ${PICO_TINYUSB_PATH}/lib/fatfs)
-        list(APPEND tinyusb_example_ignore_list
-            msc_file_explorer msc_file_explorer_freertos # need fatfs repo
-        )
+    family_filter(SHOULD_ADD "${DIR}")
+    if (SHOULD_ADD)
+        if (NOT IS_DIRECTORY ${PICO_TINYUSB_PATH}/lib/fatfs)
+            list(APPEND tinyusb_example_ignore_list
+                msc_file_explorer msc_file_explorer_freertos # need fatfs repo
+            )
+        endif()
+        if (NOT TARGET FreeRTOS-Kernel)
+            # skip freertos examples
+            list(APPEND tinyusb_example_ignore_list
+                ${tinyusb_freertos_examples}
+            )
+        endif()
+        list(FIND tinyusb_example_ignore_list ${DIR} skip_pos)
+        if (skip_pos LESS 0)
+            add_subdirectory(${DIR})
+        endif()
     endif()
-    if (NOT TARGET FreeRTOS-Kernel)
-        # skip freertos examples
-        list(APPEND tinyusb_example_ignore_list
-            ${tinyusb_freertos_examples}
-        )
-    endif()
-    list(FIND tinyusb_example_ignore_list ${DIR} skip_pos)
-    if (skip_pos LESS 0)
-        add_subdirectory(${DIR})
-    endif()
-endif()
 endfunction()
-
 
 if (TARGET tinyusb_device)
     add_subdirectory(device)

--- a/usb/CMakeLists.txt
+++ b/usb/CMakeLists.txt
@@ -11,10 +11,9 @@ set(tinyusb_freertos_examples
     msc_file_explorer_freertos
 )
 
-# this function is added in later TinyUSB but requires
-# tools/get_deps.py to have been runing withint TinyUSB
-#
-# it just prints out code sizes which isn't really needed
+# This function is added in later TinyUSB, but requires
+# tools/get_deps.py to have been run within TinyUSB.
+# It just prints out code sizes which isn't really needed
 # here, so just make it a no-op
 function(family_add_linkermap TARGET)
 endfunction()

--- a/usb/device/dev_hid_composite/CMakeLists.txt
+++ b/usb/device/dev_hid_composite/CMakeLists.txt
@@ -15,6 +15,8 @@ target_include_directories(dev_hid_composite PUBLIC
 # for TinyUSB device support and tinyusb_board for the additional board support library used by the example
 target_link_libraries(dev_hid_composite PUBLIC pico_stdlib pico_unique_id tinyusb_device tinyusb_board)
 
+target_compile_definitions(dev_hid_composite PUBLIC CFG_TUSB_OS=OPT_OS_PICO)
+
 # Uncomment this line to enable fix for Errata RP2040-E5 (the fix requires use of GPIO 15)
 #target_compile_definitions(dev_hid_composite PUBLIC PICO_RP2040_USB_DEVICE_ENUMERATION_FIX=1)
 

--- a/usb/device/dev_multi_cdc/CMakeLists.txt
+++ b/usb/device/dev_multi_cdc/CMakeLists.txt
@@ -24,6 +24,8 @@ target_compile_definitions(dev_multi_cdc PUBLIC
 # for TinyUSB device support and tinyusb_board for the additional board support library used by the example
 target_link_libraries(dev_multi_cdc PUBLIC pico_stdlib pico_unique_id tinyusb_device tinyusb_board)
 
+target_compile_definitions(dev_multi_cdc PUBLIC CFG_TUSB_OS=OPT_OS_PICO)
+
 pico_enable_stdio_usb(dev_multi_cdc 1)
 pico_add_extra_outputs(dev_multi_cdc)
 

--- a/usb/host/host_cdc_msc_hid/CMakeLists.txt
+++ b/usb/host/host_cdc_msc_hid/CMakeLists.txt
@@ -18,6 +18,8 @@ target_include_directories(host_cdc_msc_hid PUBLIC
 # for TinyUSB device support and tinyusb_board for the additional board support library used by the example
 target_link_libraries(host_cdc_msc_hid PUBLIC pico_stdlib tinyusb_host tinyusb_board)
 
+target_compile_definitions(host_cdc_msc_hid PUBLIC CFG_TUSB_OS=OPT_OS_PICO)
+
 pico_add_extra_outputs(host_cdc_msc_hid)
 
 # add url via pico_set_program_url


### PR DESCRIPTION
* Explicitly set CFG_TUSB_OS=OPT_OS_PICO on our local TinyUSB examples
* Set TINYUSB_OPT_OS=OPT_OS_PICO in the CMake scope for TinyUSB examples